### PR TITLE
TFT_eSPI+parallel

### DIFF
--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -79,8 +79,10 @@
 #elif defined (ESP32)
   //#define DC_C digitalWrite(TFT_DC, HIGH); GPIO.out_w1tc = (1 << TFT_DC)//digitalWrite(TFT_DC, LOW)
   //#define DC_D digitalWrite(TFT_DC, LOW); GPIO.out_w1ts = (1 << TFT_DC)//digitalWrite(TFT_DC, HIGH)
-  #define DC_C GPIO.out_w1ts = (1 << TFT_DC); GPIO.out_w1ts = (1 << TFT_DC); GPIO.out_w1tc = (1 << TFT_DC)
-  #define DC_D GPIO.out_w1tc = (1 << TFT_DC); GPIO.out_w1ts = (1 << TFT_DC)
+  // #define DC_C GPIO.out_w1ts = (1 << TFT_DC); GPIO.out_w1ts = (1 << TFT_DC); GPIO.out_w1tc = (1 << TFT_DC)
+  // #define DC_D GPIO.out_w1tc = (1 << TFT_DC); GPIO.out_w1ts = (1 << TFT_DC)
+  #define DC_C GPIO.out_w1tc |= (1 << TFT_DC)
+  #define DC_D GPIO.out_w1ts |= (1 << TFT_DC)  
 #else
   #define DC_C GPOC=dcpinmask
   #define DC_D GPOS=dcpinmask
@@ -96,8 +98,11 @@
   #elif defined (ESP32)
     //#define CS_L digitalWrite(TFT_CS, HIGH); GPIO.out_w1tc = (1 << TFT_CS)//digitalWrite(TFT_CS, LOW)
     //#define CS_H digitalWrite(TFT_CS, LOW); GPIO.out_w1ts = (1 << TFT_CS)//digitalWrite(TFT_CS, HIGH)
-    #define CS_L GPIO.out_w1ts = (1 << TFT_CS);GPIO.out_w1tc = (1 << TFT_CS)
-    #define CS_H GPIO.out_w1ts = (1 << TFT_CS)
+    // #define CS_L GPIO.out_w1ts = (1 << TFT_CS);GPIO.out_w1tc = (1 << TFT_CS)
+    // #define CS_H GPIO.out_w1ts = (1 << TFT_CS)
+    #define CS_L GPIO.out_w1tc |= (1 << TFT_CS)
+    //#define CS_H GPIO.out_w1ts |= (1 << TFT_CS)	
+	#define CS_H
   #else
     #define CS_L GPOC=cspinmask
     #define CS_H GPOS=cspinmask
@@ -106,9 +111,9 @@
 
 #ifdef TFT_WR
   #if defined (ESP32)
-    #define WR_L GPIO.out_w1tc = (1 << TFT_WR)
+    #define WR_L GPIO.out_w1tc |= (1 << TFT_WR)
     //digitalWrite(TFT_WR, LOW)
-    #define WR_H GPIO.out_w1ts = (1 << TFT_WR)
+    #define WR_H GPIO.out_w1ts |= (1 << TFT_WR)
     //digitalWrite(TFT_WR, HIGH)
   #else
     #define WR_L GPOC=wrpinmask
@@ -359,6 +364,10 @@ class TFT_eSPI : public Print {
            spiwrite(uint8_t),
            writecommand(uint8_t c),
            writedata(uint8_t d),
+#if defined(ESP32_PARALLEL)		   
+           writedata16(uint16_t d),		   
+           writedata32(uint32_t d),		   
+#endif		   
            commandList(const uint8_t *addr);
 
   uint8_t  readcommand8(uint8_t cmd_function, uint8_t index);

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -13,10 +13,13 @@
 //
 // ##################################################################################
 
+// Use ESP32 Parallel interface instead of SPI
+#define ESP32_PARALLEL
+
 // Only define one driver, the other ones must be commented out
-#define ILI9341_DRIVER
+//#define ILI9341_DRIVER
 //#define ST7735_DRIVER
-//#define ILI9163_DRIVER
+#define ILI9163_DRIVER
 //#define S6D02A1_DRIVER
 //#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
 
@@ -80,9 +83,21 @@
 
 // For ModeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
 
-#define TFT_CS   PIN_D8  // Chip select control pin D8
-#define TFT_DC   PIN_D3  // Data Command control pin
-#define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
+#define TFT_CS   2  // Chip select control pin D8
+#define TFT_DC   4  // Data Command control pin
+#define TFT_RST  0  // Reset pin (could connect to NodeMCU RST, see next line)
+
+#define TFT_WR	 5  
+#define TFT_RD   21      // /RD signal connected to Arduino digital pin 32
+#define TFT_D0   12
+#define TFT_D1   13
+#define TFT_D2   14
+#define TFT_D3   15
+#define TFT_D4   16
+#define TFT_D5   17
+#define TFT_D6   18
+#define TFT_D7   19
+
 //#define TFT_RST  -1  // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
 
 //#define TFT_WR PIN_D2    // Write strobe for modified Raspberry Pi TFT only


### PR DESCRIPTION
Hi Bodmer,

This commit might not be suitable for the TFT_eSPI library...
    
What I've implemented is a parallel interface for ES32 to a TFT display with ILI_9163 driver.     I have not implemented the routines that are reading from the display... as I do nto need them I think.

I have tested all the example schetches on a ESP32 NodeMCU together with a TFT 1.8" screen from NewHavenDisplay (http://www.newhavendisplay.com/nhd18128160efcsxnf-p-9493.html)
    
The reason for selecting the display is that it was the only one with Sunligt Readable capability (1000cd), and it only has a parallel interface.
    
I would appreciate if the changes could somehow be incorporated into TFT_eSPI.

Please let me know what you think.
    
Regards,
Knut