### PR TITLE
ST7787 and 3-wire protocol support for TFT_eSPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Backup files
+*~
+
 # =========================
 # Operating System Files
 # =========================

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # TFT_eSPI
 
-An Arduino IDE compatible graphics and fonts library for ESP8266 and ESP32 processors with a driver for ILI9341, ILI9163, ST7735 and S6D02A1 based TFT displays that support SPI.
+An Arduino IDE compatible graphics and fonts library for ESP8266 and ESP32 processors with a driver for ILI9341, ILI9163, ST7735, ST7787 and S6D02A1 based TFT displays that support SPI.
 
 The library also supports TFT displays designed for the Raspberry Pi that are based on a ILI9486 driver chip with a 480 x 320 pixel screen. This display must be of the Waveshare design and use a 16 bit serial interface based on the 74HC04, 74HC4040 and 2 x 74HC4094 logic chips. A modification to these displays is possible (see mod image in Tools folder) to make many graphics functions much faster (e.g. 23ms to clear the screen, 1.2ms to draw a 72 pixel high numeral).
 
 The library supports SPI overlap so the TFT screen can share MOSI, MISO and SCLK pins with the program FLASH.
+
+The library supports the 3-wire mode of some display controllers (currently tested with ST7787 only, and currently only on ESP8266). This mode reduces pin count by not using the DC and MISO pins.
+
 
 The library contains proportional fonts, different sizes can be enabled/disabled at compile time to optimise the use of FLASH memory.  The library has been tested with the NodeMCU (ESP8266 based) and an ESP32 demo board.
 

--- a/TFT_Drivers/ST7787_Defines.h
+++ b/TFT_Drivers/ST7787_Defines.h
@@ -1,0 +1,116 @@
+// Change the width and height if required (defined in portrait mode)
+// or use the constructor to over-ride defaults
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH  240
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 320
+#endif
+
+
+// Color definitions for backwards compatibility with old sketches
+// use colour definitions like TFT_BLACK to make sketches more portable
+#define ST7735_BLACK       0x0000      /*   0,   0,   0 */
+#define ST7735_NAVY        0x000F      /*   0,   0, 128 */
+#define ST7735_DARKGREEN   0x03E0      /*   0, 128,   0 */
+#define ST7735_DARKCYAN    0x03EF      /*   0, 128, 128 */
+#define ST7735_MAROON      0x7800      /* 128,   0,   0 */
+#define ST7735_PURPLE      0x780F      /* 128,   0, 128 */
+#define ST7735_OLIVE       0x7BE0      /* 128, 128,   0 */
+#define ST7735_LIGHTGREY   0xC618      /* 192, 192, 192 */
+#define ST7735_DARKGREY    0x7BEF      /* 128, 128, 128 */
+#define ST7735_BLUE        0x001F      /*   0,   0, 255 */
+#define ST7735_GREEN       0x07E0      /*   0, 255,   0 */
+#define ST7735_CYAN        0x07FF      /*   0, 255, 255 */
+#define ST7735_RED         0xF800      /* 255,   0,   0 */
+#define ST7735_MAGENTA     0xF81F      /* 255,   0, 255 */
+#define ST7735_YELLOW      0xFFE0      /* 255, 255,   0 */
+#define ST7735_WHITE       0xFFFF      /* 255, 255, 255 */
+#define ST7735_ORANGE      0xFD20      /* 255, 165,   0 */
+#define ST7735_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
+#define ST7735_PINK        0xF81F
+
+#define ILI9341_BLACK ST7735_BLACK
+
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80
+
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+
+#define TFT_RAMRD   0x2E
+#define TFT_IDXRD   0x00 //0xDD // ILI9341 only, indexed control register read
+
+#define TFT_MADCTL  0x36
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_BGR 0x08
+#define TFT_MAD_MH  0x04
+#define TFT_MAD_RGB 0x00
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+
+// ST7787 specific commands used in init
+#define ST7787_NOP     0x00
+#define ST7787_SWRESET 0x01
+#define ST7787_RDDID   0x04
+#define ST7787_RDDST   0x09
+
+#define ST7787_SLPIN   0x10
+#define ST7787_SLPOUT  0x11
+#define ST7787_PTLON   0x12
+#define ST7787_NORON   0x13
+
+#define ST7787_INVOFF  0x20
+#define ST7787_INVON   0x21
+#define ST7787_DISPOFF 0x28
+#define ST7787_DISPON  0x29
+#define ST7787_CASET   0x2A
+#define ST7787_RASET   0x2B // PASET
+#define ST7787_RAMWR   0x2C
+#define ST7787_RAMRD   0x2E
+
+#define ST7787_PTLAR   0x30
+#define ST7787_MADCTL  0x36
+#define ST7787_COLMOD  0x3A
+
+#define ST7787_FRMCTR1 0xB1
+#define ST7787_FRMCTR2 0xB2
+#define ST7787_FRMCTR3 0xB3
+#define ST7787_INVCTR  0xB4
+#define ST7787_DISSET5 0xB6
+#define ST7787_VSYNCOUT 0xBC
+#define ST7787_VSYNCIN 0xBD
+
+#define ST7787_PWCTR1  0xC0
+#define ST7787_PWCTR2  0xC1
+#define ST7787_PWCTR3  0xC2
+#define ST7787_PWCTR4  0xC3
+#define ST7787_PWCTR5  0xC4
+#define ST7787_VMCTR1  0xC5
+
+#define ST7787_RDID1   0xDA
+#define ST7787_RDID2   0xDB
+#define ST7787_RDID3   0xDC
+
+#define ST7787_GMCTRP1 0xE0
+#define ST7787_GMCTRN1 0xE1
+
+/* Timing delays from ST7787 datasheet (in nanoseconds). */
+#define ST7787_T_CSS 60
+#define ST7787_T_SCC 20
+#define ST7787_T_CHW 40
+#define ST7787_T_SHW 20
+#define ST7787_T_SLW 20
+#define ST7787_T_SHR 60
+#define ST7787_T_SLR 60

--- a/TFT_Drivers/ST7787_Defines.h
+++ b/TFT_Drivers/ST7787_Defines.h
@@ -85,6 +85,8 @@
 
 #define ST7787_PTLAR   0x30
 #define ST7787_SCRLAR  0x33
+#define ST7787_TEOFF   0x34
+#define ST7787_TEON    0x35
 #define ST7787_MADCTL  0x36
 #define ST7787_VSCSAD  0x37
 #define ST7787_COLMOD  0x3A

--- a/TFT_Drivers/ST7787_Defines.h
+++ b/TFT_Drivers/ST7787_Defines.h
@@ -31,7 +31,10 @@
 #define ST7735_PINK        0xF81F
 
 #define ILI9341_BLACK ST7735_BLACK
+#define ILI9341_WHITE ST7735_WHITE
 
+#define ILI9341_VSCRDEF ST7787_SCRLAR
+#define ILI9341_VSCRSADD ST7787_VSCSAD
 
 // Delay between some initialisation commands
 #define TFT_INIT_DELAY 0x80
@@ -81,7 +84,9 @@
 #define ST7787_RAMRD   0x2E
 
 #define ST7787_PTLAR   0x30
+#define ST7787_SCRLAR  0x33
 #define ST7787_MADCTL  0x36
+#define ST7787_VSCSAD  0x37
 #define ST7787_COLMOD  0x3A
 
 #define ST7787_FRMCTR1 0xB1

--- a/TFT_Drivers/ST7787_Init.h
+++ b/TFT_Drivers/ST7787_Init.h
@@ -1,0 +1,37 @@
+
+// This is the command sequence that initialises the ST7787 driver
+//
+// This setup information uses simple 8 bit SPI writecommand() and writedata() functions
+//
+// See ST7735_Setup.h file for an alternative format
+
+{
+  /* Take the display out of sleep mode. */
+  writecommand(ST7787_SLPOUT);
+  /*
+    Wait for sleep-out command to complete.
+    Datasheet says 5 msec is enough before next command, but 120 msec is
+    needed before the display is fully out of sleep mode.
+  */
+  delay(120);
+  /*
+    Select 16-bit 565 RGB pixel format (mode 5).
+    Same for RGB mode (but we don't use it).
+  */
+  writecommand(ST7787_COLMOD);
+  writedata((13 << 4) | 5);
+  /* Disable external vsync. */
+  writecommand(ST7787_VSYNCOUT);
+  /* Turn on the display */
+  writecommand(ST7787_DISPON);
+
+  {
+    /* Debug: Read ID and status, to see if the basics are working. */
+    uint8_t buf[4];
+    docommand(ST7787_RDDID, NULL, 0, buf, 3);
+    Serial.print("RDDID: "); Serial.print(buf[0], HEX); Serial.print(" "); Serial.print(buf[1], HEX); Serial.print(" "); Serial.print(buf[2], HEX); Serial.print("\r\n");
+    docommand(ST7787_RDDST, NULL, 0, buf, 4);
+    Serial.print("RDDST: "); Serial.print(buf[0], HEX); Serial.print(" "); Serial.print(buf[1], HEX); Serial.print(" "); Serial.print(buf[2], HEX); Serial.print(" "); Serial.print(buf[3], HEX); Serial.print("\r\n");
+    for (;;) { }
+  }
+}

--- a/TFT_Drivers/ST7787_Init.h
+++ b/TFT_Drivers/ST7787_Init.h
@@ -24,14 +24,4 @@
   writecommand(ST7787_VSYNCOUT);
   /* Turn on the display */
   writecommand(ST7787_DISPON);
-
-  {
-    /* Debug: Read ID and status, to see if the basics are working. */
-    uint8_t buf[4];
-    docommand(ST7787_RDDID, NULL, 0, buf, 3);
-    Serial.print("RDDID: "); Serial.print(buf[0], HEX); Serial.print(" "); Serial.print(buf[1], HEX); Serial.print(" "); Serial.print(buf[2], HEX); Serial.print("\r\n");
-    docommand(ST7787_RDDST, NULL, 0, buf, 4);
-    Serial.print("RDDST: "); Serial.print(buf[0], HEX); Serial.print(" "); Serial.print(buf[1], HEX); Serial.print(" "); Serial.print(buf[2], HEX); Serial.print(" "); Serial.print(buf[3], HEX); Serial.print("\r\n");
-    for (;;) { }
-  }
 }

--- a/TFT_Drivers/ST7787_Init.h
+++ b/TFT_Drivers/ST7787_Init.h
@@ -20,6 +20,9 @@
   */
   writecommand(ST7787_COLMOD);
   writedata((13 << 4) | 5);
+  /* Initialise to Rotation 0. */
+  writecommand(TFT_MADCTL);
+  writedata(TFT_MAD_ML | TFT_MAD_RGB);
   /* Disable external vsync. */
   writecommand(ST7787_VSYNCOUT);
   /* Turn on the display */

--- a/TFT_Drivers/ST7787_Rotation.h
+++ b/TFT_Drivers/ST7787_Rotation.h
@@ -1,17 +1,25 @@
 
-// This is the command sequence that rotates the ST7735 driver coordinate frame
+// This is the command sequence that rotates the ST7787 driver coordinate frame
+//
+// Rotation 0 is portrait mode. Rotations 1, 2, and 3 are rotated clockwise
+// by 90, 180, and 270 degrees.
+//
+// Vertical refresh direction is set to be the same as data write order.
+// So coordinate 0 is refresh first, and coordinate 319 is refreshed last.
+// For some reason, counter to datasheet information, MADCTL must be set
+// with the ML bit as the inverse of the MY bit to achieve this.
 
   rotation = m % 4; // Limit the range of values to 0-3
 
   writecommand(TFT_MADCTL);
   switch (rotation) {
     case 0:
-      writedata(TFT_MAD_RGB);
+      writedata(TFT_MAD_ML | TFT_MAD_RGB);
       _width  = TFT_WIDTH;
       _height = TFT_HEIGHT;
       break;
     case 1:
-      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
+      writedata(TFT_MAD_ML | TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
       break;

--- a/TFT_Drivers/ST7787_Rotation.h
+++ b/TFT_Drivers/ST7787_Rotation.h
@@ -1,0 +1,28 @@
+
+// This is the command sequence that rotates the ST7735 driver coordinate frame
+
+  rotation = m % 4; // Limit the range of values to 0-3
+
+  writecommand(TFT_MADCTL);
+  switch (rotation) {
+    case 0:
+      writedata(TFT_MAD_RGB);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      break;
+    case 1:
+      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      break;
+    case 2:
+      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      break;
+    case 3:
+      writedata(TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_RGB);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      break;
+  }

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -80,10 +80,10 @@ inline void TFT_eSPI::spi_end(void){
   if(!inTransaction) {
     if (!locked) {
       locked = true;
-      SPI.endTransaction();
-      #ifdef IFACE_3WIRE_ESP8266
+    #ifdef IFACE_3WIRE_ESP8266
       SPI1U &= ~(uint32_t)(SPIUWRBYO|SPIURDBYO);
-      #endif
+    #endif
+      SPI.endTransaction();
     }
   }
   #endif
@@ -208,7 +208,6 @@ void TFT_eSPI::init(void)
   SPI.begin(); // This will set HMISO to input
 #else
   #if defined (TFT_MOSI) && !defined (TFT_SPI_OVERLAP)
-  // ToDo: handle 3-wire interface on ESP32.
     SPI.begin(TFT_SCLK, TFT_MISO, TFT_MOSI, -1);
   #else
     SPI.begin();
@@ -224,10 +223,11 @@ void TFT_eSPI::init(void)
   SPI.setBitOrder(MSBFIRST);
   SPI.setDataMode(SPI_MODE0);
   SPI.setFrequency(SPI_FREQUENCY);
+
   #ifdef IFACE_3WIRE_ESP8266
     SPI1U |= (uint32_t)(SPIUWRBYO|SPIURDBYO);
   #endif
-  
+
   #ifdef ESP32 // Unlock the SPI hal mutex and set the lock management flags
     SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
     inTransaction = true; // Flag to stop intermediate spi_end calls

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -30,6 +30,15 @@
   #define SPI_FREQUENCY  20000000
 #endif
 
+#ifdef ST7787_DRIVER
+  // ST7787 only supports a 3-wire serial interface, where the data/command bit
+  // is sent as a 9th bit in the SPI protocol, not on a separate wire.
+  #define IFACE_3WIRE 1
+  #ifdef ESP8266
+    #define IFACE_3WIRE_ESP8266 1
+  #endif
+#endif
+
 // Only load the fonts defined in User_Setup.h (to save space)
 // Set flag so RLE rendering code is optionally compiled
 #ifdef LOAD_GLCD

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -472,8 +472,17 @@ inline void spi_end() __attribute__((always_inline));
     *gfxFont;
 #endif
 
-  void delay_ns(uint32_t d) { delayMicroseconds(1); /* ToDo */ }
 };
+
+static inline void delay_ns(int32_t d)
+{
+  while (d > 0)
+  {
+    asm volatile ("nop ; nop ; nop ; nop" : : : "memory");
+    d -= 25;
+  }
+  /* ToDo */
+}
 
 #endif
 

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -129,19 +129,6 @@
   #endif
 #endif
 
-#ifdef TFT_DAT
-#define DAT_I pinMode(TFT_DAT, INPUT)
-#define DAT_O pinMode(TFT_DAT, OUTPUT)
-#define DAT_L digitalWrite(TFT_DAT, LOW)
-#define DAT_H digitalWrite(TFT_DAT, HIGH)
-#define DAT_V digitalRead(TFT_DAT)
-#endif
-
-#ifdef TFT_SCK
-#define SCK_L digitalWrite(TFT_SCK, LOW)
-#define SCK_H digitalWrite(TFT_SCK, HIGH)
-#endif
-
 #ifdef LOAD_GFXFF
   // We can include all the free fonts and they will only be built into
   // the sketch if they are used
@@ -482,16 +469,6 @@ inline void spi_end() __attribute__((always_inline));
 #endif
 
 };
-
-static inline void delay_ns(int32_t d)
-{
-  while (d > 0)
-  {
-    asm volatile ("nop ; nop ; nop ; nop" : : : "memory");
-    d -= 25;
-  }
-  /* ToDo */
-}
 
 #endif
 

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -120,6 +120,19 @@
   #endif
 #endif
 
+#ifdef TFT_DAT
+#define DAT_I pinMode(TFT_DAT, INPUT)
+#define DAT_O pinMode(TFT_DAT, OUTPUT)
+#define DAT_L digitalWrite(TFT_DAT, LOW)
+#define DAT_H digitalWrite(TFT_DAT, HIGH)
+#define DAT_V digitalRead(TFT_DAT)
+#endif
+
+#ifdef TFT_SCK
+#define SCK_L digitalWrite(TFT_SCK, LOW)
+#define SCK_H digitalWrite(TFT_SCK, HIGH)
+#endif
+
 #ifdef LOAD_GFXFF
   // We can include all the free fonts and they will only be built into
   // the sketch if they are used
@@ -361,6 +374,7 @@ class TFT_eSPI : public Print {
            setTextFont(uint8_t font),
 #endif
            spiwrite(uint8_t),
+           docommand(uint8_t c, uint8_t *in, uint32_t in_len, uint8_t *out, uint32_t out_len),
            writecommand(uint8_t c),
            writedata(uint8_t d),
            commandList(const uint8_t *addr);
@@ -458,6 +472,7 @@ inline void spi_end() __attribute__((always_inline));
     *gfxFont;
 #endif
 
+  void delay_ns(uint32_t d) { delayMicroseconds(1); /* ToDo */ }
 };
 
 #endif

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -85,8 +85,6 @@
 //#define TFT_DC   PIN_D3  // Data Command control pin
 #define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
 //#define TFT_RST  -1  // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
-#define TFT_SCK PIN_D5
-#define TFT_DAT PIN_D7
 
 //#define TFT_WR PIN_D2    // Write strobe for modified Raspberry Pi TFT only
 

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -14,15 +14,16 @@
 // ##################################################################################
 
 // Only define one driver, the other ones must be commented out
-#define ILI9341_DRIVER
+//#define ILI9341_DRIVER
 //#define ST7735_DRIVER
 //#define ILI9163_DRIVER
 //#define S6D02A1_DRIVER
 //#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
+#define ST7787_DRIVER
 
 // For ST7735 and ILI9163 ONLY, define the pixel width and height in portrait orientation
-//#define TFT_WIDTH  128
-//#define TFT_HEIGHT 160
+#define TFT_WIDTH  240
+#define TFT_HEIGHT 320
 //#define TFT_HEIGHT 128
 
 // For ST7735 ONLY, define the type of display, originally this was based on the
@@ -81,9 +82,11 @@
 // For ModeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
 
 #define TFT_CS   PIN_D8  // Chip select control pin D8
-#define TFT_DC   PIN_D3  // Data Command control pin
+//#define TFT_DC   PIN_D3  // Data Command control pin
 #define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
 //#define TFT_RST  -1  // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
+#define TFT_SCK PIN_D5
+#define TFT_DAT PIN_D7
 
 //#define TFT_WR PIN_D2    // Write strobe for modified Raspberry Pi TFT only
 

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -14,16 +14,16 @@
 // ##################################################################################
 
 // Only define one driver, the other ones must be commented out
-//#define ILI9341_DRIVER
+#define ILI9341_DRIVER
 //#define ST7735_DRIVER
 //#define ILI9163_DRIVER
 //#define S6D02A1_DRIVER
 //#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
-#define ST7787_DRIVER
+//#define ST7787_DRIVER
 
 // For ST7735 and ILI9163 ONLY, define the pixel width and height in portrait orientation
-#define TFT_WIDTH  240
-#define TFT_HEIGHT 320
+//#define TFT_WIDTH  128
+//#define TFT_HEIGHT 160
 //#define TFT_HEIGHT 128
 
 // For ST7735 ONLY, define the type of display, originally this was based on the
@@ -82,7 +82,7 @@
 // For ModeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
 
 #define TFT_CS   PIN_D8  // Chip select control pin D8
-//#define TFT_DC   PIN_D3  // Data Command control pin
+#define TFT_DC   PIN_D3  // Data Command control pin
 #define TFT_RST  PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
 //#define TFT_RST  -1  // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
 
@@ -158,8 +158,8 @@
 // #define SPI_FREQUENCY   1000000
 // #define SPI_FREQUENCY   5000000
 // #define SPI_FREQUENCY  10000000
-#define SPI_FREQUENCY  20000000
-// #define SPI_FREQUENCY  27000000 // Actually sets it to 26.67MHz = 80/3
+// #define SPI_FREQUENCY  20000000
+ #define SPI_FREQUENCY  27000000 // Actually sets it to 26.67MHz = 80/3
 // #define SPI_FREQUENCY  40000000 // Maximum to use SPIFFS
 // #define SPI_FREQUENCY  80000000
 

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -73,6 +73,11 @@
 //
 // See Section 2. below if DC or CS is connected to D0
 //
+// On ST7787, using 3-wire mode, the DC pin is not needed and TFT_DC can be
+// left undefined. MOSI should be connected to D0 on the display. MISO should
+// also be connected to D0 to be able to read from the display, or can be left
+// unconnected if reading is not needed.
+//
 // Note: only some versions of the NodeMCU provide the USB 5V on the VIN pin
 // If 5V is not available at a pin you can use 3.3V but backlight brightness
 // will be lower.

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -160,8 +160,8 @@
 // #define SPI_FREQUENCY   1000000
 // #define SPI_FREQUENCY   5000000
 // #define SPI_FREQUENCY  10000000
-// #define SPI_FREQUENCY  20000000
- #define SPI_FREQUENCY  27000000 // Actually sets it to 26.67MHz = 80/3
+#define SPI_FREQUENCY  20000000
+// #define SPI_FREQUENCY  27000000 // Actually sets it to 26.67MHz = 80/3
 // #define SPI_FREQUENCY  40000000 // Maximum to use SPIFFS
 // #define SPI_FREQUENCY  80000000
 

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -51,6 +51,8 @@
      #include <TFT_Drivers/S6D02A1_Defines.h>
 #elif defined (RPI_ILI9486_DRIVER)
      #include <TFT_Drivers/RPI_ILI9486_Defines.h>
+#elif defined (ST7787_DRIVER)
+     #include <TFT_Drivers/ST7787_Defines.h>
 #endif
 
 // These are the pins for all ESP8266 boards

--- a/examples/160 x 128/Flash_Bitmap2/Flash_Bitmap2.ino
+++ b/examples/160 x 128/Flash_Bitmap2/Flash_Bitmap2.ino
@@ -28,7 +28,7 @@
 TFT_eSPI tft = TFT_eSPI();  // Invoke library, pins defined in User_Setup.h
 
 // Include the header files that contain the icons
-#include "alert.h"
+#include "Alert.h"
 #include "Close.h"
 #include "Info.h"
 

--- a/examples/320 x 240/TFT_Flash_Bitmap/TFT_Flash_Bitmap.ino
+++ b/examples/320 x 240/TFT_Flash_Bitmap/TFT_Flash_Bitmap.ino
@@ -24,7 +24,7 @@
 TFT_eSPI tft = TFT_eSPI();       // Invoke custom library
 
 // Include the header files that contain the icons
-#include "alert.h"
+#include "Alert.h"
 #include "Close.h"
 #include "Info.h"
 

--- a/examples/320 x 240/TFT_ReadPixel/TFT_ReadPixel.ino
+++ b/examples/320 x 240/TFT_ReadPixel/TFT_ReadPixel.ino
@@ -1,0 +1,61 @@
+// Test readPixel() and readRect()
+
+#include <TFT_eSPI.h> // Hardware-specific library
+#include <SPI.h>
+
+TFT_eSPI tft = TFT_eSPI();       // Invoke custom library
+
+unsigned long runTime = 0;
+
+
+void setup()
+{
+  //randomSeed(analogRead(A0));
+  Serial.begin(115200);
+
+  // Setup the LCD
+  tft.init();
+}
+
+uint16_t pixel_buf[16*16];
+
+void loop()
+{
+  runTime = millis();
+
+  tft.fillScreen(ILI9341_BLACK);
+  tft.drawPixel(1, 1, tft.color565(255, 0, 0));
+  tft.drawPixel(10, 10, tft.color565(0, 255, 0));
+  tft.drawPixel(3, 15, tft.color565(0, 0, 255));
+  tft.drawPixel(13, 4, tft.color565(30<<3, 20<<2, 10<<3));
+  Serial.println("readPixel() test:");
+  printRGB(tft.readPixel(0, 0));
+  printRGB(tft.readPixel(1, 1));
+  printRGB(tft.readPixel(10, 10));
+  printRGB(tft.readPixel(3, 15));
+  printRGB(tft.readPixel(13, 4));
+
+  tft.fillRect(20, 5, 18, 18, tft.color565(0x22, 0x22, 0x22));
+  tft.drawPixel(11, 10, tft.color565(3<<3, 5<<2, 9<<3));
+  tft.drawPixel(10, 11, tft.color565(0<<3, 1<<2, 2<<3));
+  Serial.println("readRect() test:");
+  tft.readRect(10, 10, 2, 2, pixel_buf);
+  int i;
+  for (i = 0; i < 4; ++i)
+    printRGB((pixel_buf[i]<<8)|(pixel_buf[i]>>8));
+
+  tft.readRect(0, 0, 16, 16, pixel_buf);
+  tft.pushRect(20+1, 5+1, 16, 16, pixel_buf);
+
+  while(1) yield();
+}
+
+void printRGB(uint16_t pixel)
+{
+  Serial.print("RGB: ");
+  Serial.print(pixel >> 11);
+  Serial.print(" ");
+  Serial.print((pixel >> 5) & 0x3f);
+  Serial.print(" ");
+  Serial.println(pixel & 0x1f);
+}

--- a/examples/480 x 320/Flash_Bitmap/Flash_Bitmap.ino
+++ b/examples/480 x 320/Flash_Bitmap/Flash_Bitmap.ino
@@ -31,7 +31,7 @@
 TFT_eSPI tft = TFT_eSPI();                   // Invoke custom library with default width and height
 
 // Include the header files that contain the icons
-#include "alert.h"
+#include "Alert.h"
 #include "Close.h"
 #include "Info.h"
 

--- a/examples/480 x 320/TFT_ring_meter/TFT_ring_meter.ino
+++ b/examples/480 x 320/TFT_ring_meter/TFT_ring_meter.ino
@@ -15,7 +15,7 @@
 
 #define TFT_GREY 0x2104 // Dark grey 16 bit colour
 
-#include "alert.h" // Out of range alert icon
+#include "Alert.h" // Out of range alert icon
 
 #include <TFT_eSPI.h> // Hardware-specific library
 #include <SPI.h>


### PR DESCRIPTION
This pull request implements support for another display driver, the ST7787,
in your TFT_eSPI library.

With this request, I want to ask if you are interested in getting this
included in your upstream repository for others to use?

The implementation should be complete, all examples work. There is currently
only support for the ESP8266 though, ESP32 is not yet implemented.

There is some background on the project here, if you are interested:
http://kristiannielsen.livejournal.com/19836.html . Also, we have a bunch of
these displays lying around; if you are interested I can send you a couple
to play with^H^H^H^H test.

Datasheets for the display and the controller are here:

  http://www.glyn.co.nz/downloads/protected/EDT/Datasheets/TFT/ET024002DMU-RoHS%20ver%204%20-%202.4%20inch%20-%20240%20x%20320.pdf
  http://www.glyn.co.nz/downloads/protected/EDT/Datasheets/TFT/Controllers/ST7787_V1.1_20070614.pdf

The main difference with the ST7787 is that it only supports the 3-wire
serial interface - it has no DC (data/command) pin in serial mode. Instead
the D/C bit is sent as a 9th bit with every byte transmitted. Thus, all the
SPI-code needs to be modified to use 9 bits per byte. This means that the
patch adds a fair amount of code. On the other hand, the 3-wire interface is
also present in other controllers; this could be used to reduce pin count
(saving the need for the DC pin).

I tried to preserve the good performance of the library for the ST7787,
using the ESP8266 SPI hardware in a similar way. The need for 9-bit SPI
introduces some extra bit-stuffing overhead. On the other hand, since D/C is
inline in the SPI stream, multiple commands can be transmitted in one go by
the SPI hardware without manually flipping the DC pin, which might win back
a bit of performance (eg. setAddrWindow()).

The ESP32 is not supported at all for ST7787 for now. I could add it though,
if necessary (and of I can find an ESP32 to test with, shouldn't be hard).
