### PR TITLE
Conversion from 24 bit and css color notation

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -2710,7 +2710,27 @@ uint16_t TFT_eSPI::color565(uint8_t r, uint8_t g, uint8_t b)
 {
   return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
 }
+uint16_t TFT_eSPI::color565FromWebHex(const char* color){
+		if (color[0] == '#') { 
+			//remove first char
+			String c = String(color);
+			c = c.substring(1);
+			char l[9];
+			for (int i = 0; i<9; i++)
+				l[i] = '\0';
+			c.toCharArray(l, 9);
+			color = l;
+		}
 
+		int colorInt = strtol(color, NULL, 16);
+		return color565From888(colorInt);
+}
+uint16_t TFT_eSPI::color565From888(uint16_t color){
+		int r = (color >> 16) & 255; 
+		int g = (color >> 8) & 255;
+		int b = (color) & 255;
+		return color565(r, g, b);
+}
 
 /***************************************************************************************
 ** Function name:           invertDisplay

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -387,7 +387,8 @@ class TFT_eSPI : public Print {
 
   uint16_t fontsLoaded(void),
            color565(uint8_t r, uint8_t g, uint8_t b);
-
+uint16_t	   color565From888(uint16_t color);
+uint16_t	   color565FromWebHex(const char* color);
   int16_t  drawChar(unsigned int uniCode, int x, int y, int font),
            drawChar(unsigned int uniCode, int x, int y),
            drawNumber(long long_num,int poX, int poY, int font),


### PR DESCRIPTION
I have opened an issue a few days ago about the colors from hex value and struggled a bit to get a working solution. Therefore I would like to add this feature so other beginners could save some time.
Now you can get a 16 bit color that pretty much reassembles the 24 bit one with either
`tft.color565From888(0xffffff);` or `tft.color565FromWebHex("#ffffff");`