### PR TITLE
ESP32 Change use of SPI transactions

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -192,9 +192,16 @@ void TFT_eSPI::init(void)
   SPI.setFrequency(SPI_FREQUENCY);
 
   #ifdef ESP32 // Unlock the SPI hal mutex and set the lock management flags
-    SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
-    inTransaction = true; // Flag to stop intermediate spi_end calls
-    locked = false;       // Flag to stop repeat beginTransaction calls
+    #ifdef SUPPORT_TRANSACTIONS
+      SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
+      inTransaction = true; // Flag to stop intermediate spi_end calls
+      locked = false;       // Flag to stop repeat beginTransaction calls
+    #else
+      SPI.begin(TFT_SCLK,TFT_MISO,TFT_MOSI);
+      SPI.setFrequency(SPI_FREQUENCY);
+      SPI.setBitOrder(MSBFIRST);
+      SPI.setDataMode(SPI_MODE0);
+    #endif
   #endif
 
 #endif


### PR DESCRIPTION
Using the #define SUPPORT_TRANSACTIONS to initialize SPI on ESP32 with or without transaction support.

Digging a little bit more into my problem with ArduinoOTA and TFT_eSPI. As transactions eat up a little performance I tried to use SPI on the ESP32 without transactions. Instead of 
_**`SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));`**_
I initialized SPI with
```
SPI.begin(TFT_SCLK,TFT_MISO,TFT_MOSI);
SPI.setFrequency(SPI_FREQUENCY);
SPI.setBitOrder(MSBFIRST);
SPI.setDataMode(SPI_MODE0);
```
This initializations works as well and does not use SPI transactions.  And transactions are only needed if several devices are connected to the same bus.

A small code change gives the user the same possibilities than on an ESP8266, to choose if SPI transactions are needed and used.
```
  #ifdef ESP32 // Unlock the SPI hal mutex and set the lock management flags
    #ifdef SUPPORT_TRANSACTIONS
      SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
      inTransaction = true; // Flag to stop intermediate spi_end calls
      locked = false;       // Flag to stop repeat beginTransaction calls
    #else
      SPI.begin(TFT_SCLK,TFT_MISO,TFT_MOSI);
      SPI.setFrequency(SPI_FREQUENCY);
      SPI.setBitOrder(MSBFIRST);
      SPI.setDataMode(SPI_MODE0);
    #endif
  #endif
```
Tested on my ESP32 Dev module with the ILI9163 TFT display.