### PR TITLE
Fix width/height override issue when using setRotation

### DIFF
--- a/TFT_Drivers/ILI9163_Rotation.h
+++ b/TFT_Drivers/ILI9163_Rotation.h
@@ -7,8 +7,8 @@
   switch (rotation) {
     case 0:
       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
 	  #ifdef CGRAM_OFFSET
         colstart = 0;
         rowstart = 0;
@@ -16,8 +16,8 @@
       break;
     case 1:
       writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
 	  #ifdef CGRAM_OFFSET
         colstart = 0;
         rowstart = 0;
@@ -25,8 +25,8 @@
       break;
     case 2:
       writedata(TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
 	  #ifdef CGRAM_OFFSET
         colstart = 0;
         rowstart = 32;
@@ -34,8 +34,8 @@
       break;
     case 3:
       writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
 	  #ifdef CGRAM_OFFSET
         colstart = 32;
         rowstart = 0;

--- a/TFT_Drivers/ILI9341_Rotation.h
+++ b/TFT_Drivers/ILI9341_Rotation.h
@@ -7,44 +7,44 @@
   switch (rotation) {
     case 0:
       writedata(TFT_MAD_MX | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 1:
       writedata(TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
     case 2:
       writedata(TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 3:
       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
   // These next rotations are for bottum up BMP drawing
     case 4:
       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 5:
       writedata(TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
     case 6:
       writedata(TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 7:
       writedata(TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
 
   }

--- a/TFT_Drivers/RPI_ILI9486_Rotation.h
+++ b/TFT_Drivers/RPI_ILI9486_Rotation.h
@@ -5,43 +5,43 @@
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_BGR | TFT_MAD_MX);
-     _width  = TFT_WIDTH;
-     _height = TFT_HEIGHT;
+     _width  = _width_orig;
+     _height = _height_orig;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_BGR | TFT_MAD_MV);
-     _width  = TFT_HEIGHT;
-     _height = TFT_WIDTH;
+     _width  = _height_orig;
+     _height = _width_orig;
      break;
    case 2: // Inverter portrait
      writedata( TFT_MAD_BGR | TFT_MAD_MY);
-     _width  = TFT_WIDTH;
-     _height = TFT_HEIGHT;
+     _width  = _width_orig;
+     _height = _height_orig;
     break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_MY);
-     _width  = TFT_HEIGHT;
-     _height = TFT_WIDTH;
+     _width  = _height_orig;
+     _height = _width_orig;
      break;
    case 4: // Portrait
      writedata(TFT_MAD_BGR | TFT_MAD_MX | TFT_MAD_MY);
-     _width  = TFT_WIDTH;
-     _height = TFT_HEIGHT;
+     _width  = _width_orig;
+     _height = _height_orig;
      break;
    case 5: // Landscape (Portrait + 90)
      writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX);
-     _width  = TFT_HEIGHT;
-     _height = TFT_WIDTH;
+     _width  = _height_orig;
+     _height = _width_orig;
      break;
    case 6: // Inverter portrait
      writedata( TFT_MAD_BGR);
-     _width  = TFT_WIDTH;
-     _height = TFT_HEIGHT;
+     _width  = _width_orig;
+     _height = _height_orig;
      break;
    case 7: // Inverted landscape
      writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MY);
-     _width  = TFT_HEIGHT;
-     _height = TFT_WIDTH;
+     _width  = _height_orig;
+     _height = _width_orig;
      break;
   }
   

--- a/TFT_Drivers/S6D02A1_Rotation.h
+++ b/TFT_Drivers/S6D02A1_Rotation.h
@@ -7,22 +7,22 @@
   switch (rotation) {
     case 0:
       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 1:
       writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
     case 2:
       writedata(TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 3:
       writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
   }

--- a/TFT_Drivers/ST7735_Rotation.h
+++ b/TFT_Drivers/ST7735_Rotation.h
@@ -23,8 +23,8 @@
 	 } else {
        writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
      }
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 1:
      if (tabcolor == INITR_BLACKTAB) {
@@ -44,8 +44,8 @@
 	   } else {
        writedata(TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
      }
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
     case 2:
      if (tabcolor == INITR_BLACKTAB) {
@@ -65,8 +65,8 @@
 	   } else {
        writedata(TFT_MAD_BGR);
      }
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 3:
      if (tabcolor == INITR_BLACKTAB) {
@@ -86,30 +86,30 @@
 	   } else {
        writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
      }
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
 
   // These next rotations are for bottum up BMP drawing
   /*  case 4:
       writedata(ST7735_TFT_MAD_MX | ST7735_TFT_MAD_MY | ST7735_TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 5:
       writedata(ST7735_TFT_MAD_MV | ST7735_TFT_MAD_MX | ST7735_TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
     case 6:
       writedata(ST7735_TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _width_orig;
+      _height = _height_orig;
       break;
     case 7:
       writedata(ST7735_TFT_MAD_MY | ST7735_TFT_MAD_MV | ST7735_TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _height_orig;
+      _height = _width_orig;
       break;
   */
   }

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -109,8 +109,8 @@ TFT_eSPI::TFT_eSPI(int16_t w, int16_t h)
   }
 #endif
 
-  _width    = w; // Set by specific xxxxx_Defines.h file or by users sketch
-  _height   = h; // Set by specific xxxxx_Defines.h file or by users sketch
+  _width_orig  = _width  = w; // Set by specific xxxxx_Defines.h file or by users sketch
+  _height_orig = _height = h; // Set by specific xxxxx_Defines.h file or by users sketch
   rotation  = 0;
   cursor_y  = cursor_x    = 0;
   textfont  = 1;

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -480,6 +480,7 @@ class TFT_eSPI : public Print {
 
   int32_t  cursor_x, cursor_y, win_xe, win_ye, padX;
 
+  uint32_t _width_orig, _height_orig; // Display w/h as input, used by setRotation()
   uint32_t _width, _height; // Display w/h as modified by current rotation
   uint32_t textcolor, textbgcolor, fontsloaded, addr_row, addr_col;
 


### PR DESCRIPTION
This commit fixes an issue when setting screen width
and height from the constructor (e.g., user sketch),
followed by setRotation(i). Previously, setRotation
used TFT_WIDTH and TFT_HEIGHT, ignoring user overrides.