### PR TITLE
Allow externally defined configuration rather than User_Setup.h modifications in library

### DIFF
--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -15,7 +15,7 @@
 // Customised User_Setup files are stored in the "User_Setups" folder.
 
 // Only ONE line should be uncommented.  Add extra lines and files as needed.
-
+#ifndef USER_SETUP_LOADED
 #include <User_Setup.h>           // Default setup is root library folder
 
 //#include <User_Setups/Setup1_ILI9341.h>  // Setup file configured for my ILI9341
@@ -31,8 +31,7 @@
 //#include <User_Setups/Setup11_RPi_touch_ILI9486.h>  // Setup file configured for my stock RPi TFT with touch
 
 //#include <User_Setups/SetupX_Template.h> // Setup file template for copying/editting
-
-
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////
 //                                                                                 //


### PR DESCRIPTION
Adding ability to load settings from the calling program rather than modifying the library for each project that uses it. This is mostly for PlatformIO IDE which manages the libraries differently than Adruino IDE.