### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+     - "2.7"
+
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+install:
+    - pip install -U platformio
+
+env:
+    - PLATFORMIO_CI_SRC=examples/Sprite/Transparent_Sprite_Demo
+    - PLATFORMIO_CI_SRC="examples/160 x 128/Arduino_Life"
+
+script:
+    - platformio ci --lib="." --board=nodemcuv2 --board=nodemcu-32s


### PR DESCRIPTION
I have added script that can build library on Travis using provided examples.
I have selected two random examples that compiles properly. I am open if you think some other would be better.
I am compiling for two boards: nodemcuv2 (as example of ESP8266) and nodemcu-32s (as example of ESP32), I am not sure if some other chips are intended to be supported.

Generally this build will make more sense, with some changes that will allow injecting driver config from outside. It would allow to build multiple driver configs. I can enhance Travis run matrix when those changes will be finished.

[link to build on my travis](https://travis-ci.org/vanklompf/TFT_eSPI)
It would be best to build it form your Travis instance, because on free account it is possible only to build from own repos, so I'm not able to build from yours. Travis is free and really easy to set up.