### PR TITLE
Added public resetLcd() function

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -152,6 +152,44 @@ TFT_eSPI::TFT_eSPI(int16_t w, int16_t h)
 
 }
 
+/***************************************************************************************
+** Function name:           lcdReset
+** Description:             Resets the LCD but not the SPI interface
+***************************************************************************************/
+void TFT_eSPI::lcdReset(void)
+{
+   spi_begin();
+  writecommand(TFT_SWRST); // Software reset
+  spi_end();
+  
+  delay(5); // Wait for software reset to complete
+
+  spi_begin();
+  
+  // This loads the driver specific initialisation code  <<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVERS TO THE LIST HERE <<<<<<<<<<<<<<<<<<<<<<<
+#if   defined (ILI9341_DRIVER)
+    #include "TFT_Drivers/ILI9341_Init.h"
+
+#elif defined (ST7735_DRIVER)
+    #include "TFT_Drivers/ST7735_Init.h"
+
+#elif defined (ILI9163_DRIVER)
+    #include "TFT_Drivers/ILI9163_Init.h"
+
+#elif defined (S6D02A1_DRIVER)
+    #include "TFT_Drivers/S6D02A1_Init.h"
+     
+#elif defined (RPI_ILI9486_DRIVER)
+    #include "TFT_Drivers/RPI_ILI9486_Init.h"
+
+#endif
+
+  spi_end();
+  
+  // Preserves the rotation, in cases where lcdReset() is called after the LCD has been already initialised
+  setRotation(rotation);
+  
+}
 
 /***************************************************************************************
 ** Function name:           begin
@@ -236,33 +274,7 @@ void TFT_eSPI::init(void)
   }
 #endif
 
-  spi_begin();
-  writecommand(TFT_SWRST); // Software reset
-  spi_end();
-  
-  delay(5); // Wait for software reset to complete
-
-  spi_begin();
-  
-  // This loads the driver specific initialisation code  <<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVERS TO THE LIST HERE <<<<<<<<<<<<<<<<<<<<<<<
-#if   defined (ILI9341_DRIVER)
-    #include "TFT_Drivers/ILI9341_Init.h"
-
-#elif defined (ST7735_DRIVER)
-    #include "TFT_Drivers/ST7735_Init.h"
-
-#elif defined (ILI9163_DRIVER)
-    #include "TFT_Drivers/ILI9163_Init.h"
-
-#elif defined (S6D02A1_DRIVER)
-    #include "TFT_Drivers/S6D02A1_Init.h"
-     
-#elif defined (RPI_ILI9486_DRIVER)
-    #include "TFT_Drivers/RPI_ILI9486_Init.h"
-
-#endif
-
-  spi_end();
+  lcdReset();
 
 }
 

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -328,6 +328,8 @@ class TFT_eSPI : public Print {
 
   void     init(void), begin(void); // Same - begin included for backwards compatibility
 
+  void lcdReset(void); // Resets the display only, not the SPI interface
+
   // These are virtual so the TFT_eSprite class can override them with sprite specific functions
   virtual void     drawPixel(uint32_t x, uint32_t y, uint32_t color),
                    drawChar(int32_t x, int32_t y, unsigned char c, uint32_t color, uint32_t bg, uint8_t size),


### PR DESCRIPTION
Allows to reset the panel without messing with the SPI interface. Useful in cases where the panel needs a reset and calling the init() function would create issues as it resets the GPIOs related to SPI. For example, if MISO is not used and the related GPIO is driving something else