### PR TITLE
PartialMode and Idle mode support for ILI9163

### DIFF
--- a/TFT_Drivers/ILI9163_Defines.h
+++ b/TFT_Drivers/ILI9163_Defines.h
@@ -66,3 +66,6 @@
 #define TFT_PTLAR  0x30 //partial area
 #define TFT_IDMOFF 0x38 //idle mode off
 #define TFT_IDMON  0x39 //idle mode on
+
+#define TFT_PWCTR1 0xC0
+#define TFT_PWCTR2 0xC1

--- a/TFT_Drivers/ILI9163_Defines.h
+++ b/TFT_Drivers/ILI9163_Defines.h
@@ -61,6 +61,8 @@
 #define TFT_INVOFF  0x20
 #define TFT_INVON   0x21
 
-#define TFT_NORON 0x13 //normal mode
-#define TFT_PTLON 0x12 //partial mode
-#define TFT_PTLAR 0x30 //partial area
+#define TFT_NORON  0x13 //normal mode
+#define TFT_PTLON  0x12 //partial mode
+#define TFT_PTLAR  0x30 //partial area
+#define TFT_IDMOFF 0x38 //idle mode off
+#define TFT_IDMON  0x39 //idle mode on

--- a/TFT_Drivers/ILI9163_Defines.h
+++ b/TFT_Drivers/ILI9163_Defines.h
@@ -60,3 +60,7 @@
 
 #define TFT_INVOFF  0x20
 #define TFT_INVON   0x21
+
+#define TFT_NORON 0x13 //normal mode
+#define TFT_PTLON 0x12 //partial mode
+#define TFT_PTLAR 0x30 //partial area

--- a/TFT_Drivers/ILI9163_Init.h
+++ b/TFT_Drivers/ILI9163_Init.h
@@ -11,7 +11,7 @@
 	static const uint8_t ILI9163_cmds[] PROGMEM =
 	{
 	17,    // 17 commands follow
-	0x01,  0 + TFT_INIT_DELAY, 120,  // Software reset
+	TFT_SWRST,  0 + TFT_INIT_DELAY, 120,  // Software reset
 	0x11,  0 + TFT_INIT_DELAY, 5,    // Exit sleep mode
 	0x3A,  1, 0x05, // Set pixel format
 	0x26,  1, 0x04, // Set Gamma curve 3
@@ -22,8 +22,8 @@
 	          0x3D, 0x18, 0x25, 0x2A, 0x2B, 0x2B, 0x3A, // Negative Gamma
 	0xB1,  2, 0x08, 0x08, // Frame rate control 1
 	0xB4,  1, 0x07,       // Display inversion
-	0xC0,  2, 0x0A, 0x02, // Power control 1
-	0xC1,  1, 0x02,       // Power control 2
+	TFT_PWCTR1,  2, 0x0A, 0x02, // Power control 1
+	TFT_PWCTR2,  1, 0x02,       // Power control 2
 	0xC5,  2, 0x50, 0x5B, // Vcom control 1
 	0xC7,  1, 0x40,       // Vcom offset
 	0x2A,  4, 0x00, 0x00, 0x00, 0x7F, // Set column address

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -3223,7 +3223,6 @@ uint8_t TFT_eSPI::color332(uint16_t c)
   return ((c & 0xE000)>>8) | ((c & 0x0700)>>6) | ((c & 0x0018)>>3);
 }
 
-
 /***************************************************************************************
 ** Function name:           invertDisplay
 ** Description:             invert the display colours i = 1 invert, i = 0 normal
@@ -3237,6 +3236,42 @@ void TFT_eSPI::invertDisplay(boolean i)
   spi_end();
 }
 
+/***************************************************************************************
+** Function name:           setPartialMode
+** Description:             enables/disables "partial" mode, where only part of display is active
+***************************************************************************************/
+void TFT_eSPI::setPartialMode(bool mode)
+{
+#ifdef ILI9163_DRIVER
+  spi_begin();
+  writecommand(mode ? TFT_PTLON : TFT_NORON);
+  spi_end();	
+#endif
+}
+
+/***************************************************************************************
+** Function name:           setPartialWindow
+** Description:             sets active area for partial mode. Requires partial mode to be enabled.
+**                          If endLine < startLine partial area will wrap at display edge
+***************************************************************************************/
+void TFT_eSPI::setPartialArea(int16_t startLine, int16_t endLine)
+{
+#ifdef ILI9163_DRIVER
+  if (rotation == 0 || rotation == 1)
+  {
+	  startLine = _height_orig - startLine;
+	  endLine = _height_orig - endLine;
+  }
+  
+  spi_begin();
+  writecommand(TFT_PTLAR);
+  CS_L;
+  SPI.transfer16(startLine);
+  SPI.transfer16(endLine);
+  CS_H;
+  spi_end();
+#endif
+}
 
 /***************************************************************************************
 ** Function name:           write

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -3274,6 +3274,20 @@ void TFT_eSPI::setPartialArea(int16_t startLine, int16_t endLine)
 }
 
 /***************************************************************************************
+** Function name:           setIdleMode
+** Description:             enables/disables "idle" mode, where color expression is reduced to 8 colors
+**                          can be used with partial mode, further reducing power consumption
+***************************************************************************************/
+void TFT_eSPI::setIdleMode(bool mode)
+{
+#ifdef ILI9163_DRIVER
+  spi_begin();
+  writecommand(mode ? TFT_IDMON : TFT_IDMOFF);
+  spi_end();	
+#endif
+}
+
+/***************************************************************************************
 ** Function name:           write
 ** Description:             draw characters piped through serial stream
 ***************************************************************************************/

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -355,6 +355,9 @@ class TFT_eSPI : public Print {
 
            setRotation(uint8_t r),
            invertDisplay(boolean i),
+		   
+           setPartialMode(bool mode),
+           setPartialArea(int16_t startLine, int16_t endLine),
 
            drawCircle(int32_t x0, int32_t y0, int32_t r, uint32_t color),
            drawCircleHelper(int32_t x0, int32_t y0, int32_t r, uint8_t cornername, uint32_t color),

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -355,9 +355,11 @@ class TFT_eSPI : public Print {
 
            setRotation(uint8_t r),
            invertDisplay(boolean i),
-		   
+           
            setPartialMode(bool mode),
            setPartialArea(int16_t startLine, int16_t endLine),
+           
+           setIdleMode(bool mode),
 
            drawCircle(int32_t x0, int32_t y0, int32_t r, uint32_t color),
            drawCircleHelper(int32_t x0, int32_t y0, int32_t r, uint8_t cornername, uint32_t color),


### PR DESCRIPTION
Support of partial mode, where only part of screen is active.  Can be use to reduce power consumption.
Based on ILI9163 datasheet:
https://www.rockbox.org/wiki/pub/Main/SonyNWZE370/ILI9163.pdf