### PR TITLE
Update Sprite.cpp

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -49,8 +49,8 @@ void* TFT_eSprite::createSprite(int16_t w, int16_t h, uint8_t frames)
 
   if ( w < 1 || h < 1 ) return NULL;
 
-  _iwidth  = _dwidth  = w;
-  _iheight = _dheight = h;
+  _width = _iwidth  = _dwidth  = w;
+  _height = _iheight = _dheight = h;
 
   this->cursor_x = 0;
   this->cursor_y = 0;

--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -49,8 +49,8 @@ void* TFT_eSprite::createSprite(int16_t w, int16_t h, uint8_t frames)
 
   if ( w < 1 || h < 1 ) return NULL;
 
-  _width = _iwidth  = _dwidth  = w;
-  _height = _iheight = _dheight = h;
+  this->_width = _iwidth  = _dwidth  = w;
+  this->_height = _iheight = _dheight = h;
 
   this->cursor_x = 0;
   this->cursor_y = 0;


### PR DESCRIPTION
Hi,
I found a bug.

_width and _height need to be initialized properly.

That is because they are used in drawString(). Lines 4118 and 4120 in TFT_eSPI.cpp.