### PR TITLE
Added ST7789 initialization

### DIFF
--- a/TFT_Drivers/ST7789_Defines.h
+++ b/TFT_Drivers/ST7789_Defines.h
@@ -1,7 +1,11 @@
 // Change the width and height if required (defined in portrait mode)
 // or use the constructor to over-ride defaults
-#define TFT_WIDTH  240
-#define TFT_HEIGHT 240
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH  240
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 320
+#endif
 
 #define CGRAM_OFFSET
 
@@ -15,25 +19,20 @@
 
 #define TFT_SLPIN   0x10
 #define TFT_SLPOUT  0x11
-
 #define TFT_NORON   0x13
 
 #define TFT_INVOFF  0x20
 #define TFT_INVON   0x21
-
 #define TFT_DISPOFF 0x28
 #define TFT_DISPON  0x29
-
 #define TFT_CASET   0x2A
 #define TFT_PASET   0x2B
 #define TFT_RAMWR   0x2C
-
 #define TFT_RAMRD   0x2E
-
 #define TFT_MADCTL  0x36
-
 #define TFT_COLMOD  0x3A
 
+// Flags for TFT_MADCTL
 #define TFT_MAD_MY  0x80
 #define TFT_MAD_MX  0x40
 #define TFT_MAD_MV  0x20
@@ -46,4 +45,79 @@
 
 #define TFT_IDXRD   0x00 // ILI9341 only, indexed control register read
 
+// ST7789 specific commands used in init
+#define ST7789_NOP			0x00
+#define ST7789_SWRESET		0x01
+#define ST7789_RDDID		0x04
+#define ST7789_RDDST		0x09
+
+#define ST7789_RDDPM		0x0A      // Read display power mode
+#define ST7789_RDD_MADCTL	0x0B      // Read display MADCTL
+#define ST7789_RDD_COLMOD	0x0C      // Read display pixel format
+#define ST7789_RDDIM		0x0D      // Read display image mode
+#define ST7789_RDDSM		0x0E      // Read display signal mode
+#define ST7789_RDDSR		0x0F      // Read display self-diagnostic result (ST7789V)
+
+#define ST7789_SLPIN		0x10
+#define ST7789_SLPOUT		0x11
+#define ST7789_PTLON		0x12
+#define ST7789_NORON		0x13
+
+#define ST7789_INVOFF		0x20
+#define ST7789_INVON		0x21
+#define ST7789_GAMSET		0x26      // Gamma set
+#define ST7789_DISPOFF		0x28
+#define ST7789_DISPON		0x29
+#define ST7789_CASET		0x2A
+#define ST7789_RASET		0x2B
+#define ST7789_RAMWR		0x2C
+#define ST7789_RGBSET		0x2D      // Color setting for 4096, 64K and 262K colors
+#define ST7789_RAMRD		0x2E
+
+#define ST7789_PTLAR		0x30
+#define ST7789_VSCRDEF		0x33      // Vertical scrolling definition (ST7789V)
+#define ST7789_TEOFF		0x34      // Tearing effect line off
+#define ST7789_TEON			0x35      // Tearing effect line on
+#define ST7789_MADCTL		0x36      // Memory data access control
+#define ST7789_IDMOFF		0x38      // Idle mode off
+#define ST7789_IDMON		0x39      // Idle mode on
+#define ST7789_RAMWRC		0x3C      // Memory write continue (ST7789V)
+#define ST7789_RAMRDC		0x3E      // Memory read continue (ST7789V)
+#define ST7789_COLMOD		0x3A
+
+#define ST7789_RAMCTRL		0xB0      // RAM control
+#define ST7789_RGBCTRL		0xB1      // RGB control
+#define ST7789_PORCTRL		0xB2      // Porch control
+#define ST7789_FRCTRL1		0xB3      // Frame rate control
+#define ST7789_PARCTRL		0xB5      // Partial mode control
+#define ST7789_GCTRL		0xB7      // Gate control
+#define ST7789_GTADJ		0xB8      // Gate on timing adjustment
+#define ST7789_DGMEN		0xBA      // Digital gamma enable
+#define ST7789_VCOMS		0xBB      // VCOMS setting
+#define ST7789_LCMCTRL		0xC0      // LCM control
+#define ST7789_IDSET		0xC1      // ID setting
+#define ST7789_VDVVRHEN		0xC2      // VDV and VRH command enable
+#define ST7789_VRHS			0xC3      // VRH set
+#define ST7789_VDVSET		0xC4      // VDV setting
+#define ST7789_VCMOFSET		0xC5      // VCOMS offset set
+#define ST7789_FRCTR2		0xC6      // FR Control 2
+#define ST7789_CABCCTRL		0xC7      // CABC control
+#define ST7789_REGSEL1		0xC8      // Register value section 1
+#define ST7789_REGSEL2		0xCA      // Register value section 2
+#define ST7789_PWMFRSEL		0xCC      // PWM frequency selection
+#define ST7789_PWCTRL1		0xD0      // Power control 1
+#define ST7789_VAPVANEN		0xD2      // Enable VAP/VAN signal output
+#define ST7789_CMD2EN		0xDF      // Command 2 enable
+#define ST7789_PVGAMCTRL	0xE0      // Positive voltage gamma control
+#define ST7789_NVGAMCTRL	0xE1      // Negative voltage gamma control
+#define ST7789_DGMLUTR		0xE2      // Digital gamma look-up table for red
+#define ST7789_DGMLUTB		0xE3      // Digital gamma look-up table for blue
+#define ST7789_GATECTRL		0xE4      // Gate control
+#define ST7789_SPI2EN		0xE7      // SPI2 enable
+#define ST7789_PWCTRL2		0xE8      // Power control 2
+#define ST7789_EQCTRL		0xE9      // Equalize time control
+#define ST7789_PROMCTRL		0xEC      // Program control
+#define ST7789_PROMEN		0xFA      // Program mode enable
+#define ST7789_NVMSET		0xFC      // NVM setting
+#define ST7789_PROMACT		0xFE      // Program action
 

--- a/TFT_Drivers/ST7789_Init.h
+++ b/TFT_Drivers/ST7789_Init.h
@@ -1,24 +1,120 @@
 
 // This is the command sequence that initialises the ST7789 driver
-
-// Configure ST7789 display
+//
+// This setup information uses simple 8 bit SPI writecommand() and writedata() functions
+//
+// See ST7735_Setup.h file for an alternative format
 
 {
-static const uint8_t PROGMEM
-  st7789[] = {
-    9,
-    TFT_SWRST, TFT_INIT_DELAY, 150,
-    TFT_SLPOUT, TFT_INIT_DELAY, 255,
-    TFT_COLMOD, 1+TFT_INIT_DELAY, 0x55, 10,
-    TFT_MADCTL, 1, TFT_MAD_RGB,
-    TFT_CASET, 4, 0x00, 0x00, 0x00, 0xF0,
-    TFT_PASET, 4, 0x00, 0x00, 0x00, 0xF0,
-    TFT_INVON, TFT_INIT_DELAY, 10,
-    TFT_NORON, TFT_INIT_DELAY, 10,
-    TFT_DISPON, TFT_INIT_DELAY, 255
-    };
+  writecommand(ST7789_SLPOUT);   // Sleep out
+  delay(120);
 
-    commandList(st7789);
+  writecommand(ST7789_NORON);    // Normal display mode on
+
+  //------------------------------display and color format setting--------------------------------//
+  writecommand(ST7789_MADCTL);
+  writedata(0x00);
+  writedata(0x48);
+
+  // JLX240 display datasheet
+  writecommand(0xB6);
+  writedata(0x0A);
+  writedata(0x82);
+
+  writecommand(ST7789_COLMOD);
+  writedata(0x55);
+
+  //--------------------------------ST7789V Frame rate setting----------------------------------//
+  writecommand(ST7789_PORCTRL);
+  writedata(0x0c);
+  writedata(0x0c);
+  writedata(0x00);
+  writedata(0x33);
+  writedata(0x33);
+
+  writecommand(ST7789_GCTRL);      // Voltages: VGH / VGL
+  writedata(0x35);
+
+  //---------------------------------ST7789V Power setting--------------------------------------//
+  writecommand(ST7789_VCOMS);
+  writedata(0x28);		// JLX240 display datasheet
+
+  writecommand(ST7789_LCMCTRL);
+  writedata(0x0C);
+
+  writecommand(ST7789_VDVVRHEN);
+  writedata(0x01);
+  writedata(0xFF);
+
+  writecommand(ST7789_VRHS);       // voltage VRHS
+  writedata(0x10);
+
+  writecommand(ST7789_VDVSET);
+  writedata(0x20);
+
+  writecommand(ST7789_FRCTR2);
+  writedata(0x0f);
+
+  writecommand(ST7789_PWCTRL1);
+  writedata(0xa4);
+  writedata(0xa1);
+
+  //--------------------------------ST7789V gamma setting---------------------------------------//
+  writecommand(ST7789_PVGAMCTRL);
+  writedata(0xd0);
+  writedata(0x00);
+  writedata(0x02);
+  writedata(0x07);
+  writedata(0x0a);
+  writedata(0x28);
+  writedata(0x32);
+  writedata(0x44);
+  writedata(0x42);
+  writedata(0x06);
+  writedata(0x0e);
+  writedata(0x12);
+  writedata(0x14);
+  writedata(0x17);
+
+  writecommand(ST7789_NVGAMCTRL);
+  writedata(0xd0);
+  writedata(0x00);
+  writedata(0x02);
+  writedata(0x07);
+  writedata(0x0a);
+  writedata(0x28);
+  writedata(0x31);
+  writedata(0x54);
+  writedata(0x47);
+  writedata(0x0e);
+  writedata(0x1c);
+  writedata(0x17);
+  writedata(0x1b);
+  writedata(0x1e);
+
+  writecommand(ST7789_INVOFF);
+
+  writecommand(ST7789_CASET);    // Column address set
+  writedata(0x00);
+  writedata(0x00);
+  writedata(0x00);
+  writedata(0xE5);    // 239
+
+  writecommand(ST7789_RASET);    // Row address set
+  writedata(0x00);
+  writedata(0x00);
+  writedata(0x01);
+  writedata(0x3F);    // 319
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  spi_end();
+  delay(120);
+  spi_begin();
+
+  writecommand(ST7789_DISPON);    //Display on
+
+  // Turn on the back-light LED
+  digitalWrite(TFT_BL, HIGH);
+  pinMode(TFT_BL, OUTPUT);
 }
-// End of ST7789 display configuration
-

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -35,7 +35,11 @@
   #define SPI_READ_FREQUENCY SPI_FREQUENCY
 #endif
 
-#define TFT_SPI_MODE SPI_MODE0
+#ifdef ST7789_DRIVER
+  #define TFT_SPI_MODE SPI_MODE3
+#else
+  #define TFT_SPI_MODE SPI_MODE0
+#endif
 
 // If the frequency is not defined, set a default
 #ifndef SPI_TOUCH_FREQUENCY

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -35,11 +35,7 @@
   #define SPI_READ_FREQUENCY SPI_FREQUENCY
 #endif
 
-#ifdef ST7789_DRIVER
-  #define TFT_SPI_MODE SPI_MODE3
-#else
-  #define TFT_SPI_MODE SPI_MODE0
-#endif
+#define TFT_SPI_MODE SPI_MODE0
 
 // If the frequency is not defined, set a default
 #ifndef SPI_TOUCH_FREQUENCY


### PR DESCRIPTION
I added ST7789 initialization sequence according to ST7789 datasheet. 
Tested with display JLX240-00302 (320x240, 2.4") which uses ST7789V display driver.

It looks like setting SPI_MODE3 for ST7789 is not needed, so I deleted that part.