### PR TITLE
Fix for smooth font anti aliasing in sprites

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -1525,7 +1525,7 @@ void TFT_eSprite::drawGlyph(uint16_t code)
           if (pixel != 0xFF)
           {
             if (dl) { drawFastHLine( xs, y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], dl, fg); dl = 0; }
-            if (pixel>127) drawPixel(x + this->cursor_x + this->gdX[gNum], y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], alphaBlend(pixel, fg, bg));
+            drawPixel(x + this->cursor_x + this->gdX[gNum], y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], alphaBlend(pixel, fg, bg));
           }
           else
           {


### PR DESCRIPTION
Currently, smooth fonts are antialiased differently depending on whether they are drawn directly on a TFT or drawn on a sprite and then pushed to the TFT.  In my opinion, the anti aliasing should be consistent, regardless of where the text is being drawn. 

Digging into the libraries, I noticed that drawGlyph() in Sprite.cpp overrides drawGlyph() in Smooth_font.cpp.  For some reason, in Sprite.cpp, drawPixel() was only being called if the alpha value of the pixel was greater than 127.  This produced weaker anti aliasing.  Removing the "if" statement and calling drawPixel() regardless of the alpha value of that pixel, resolves the inconsistency and produces great looking text!

![old-bad](https://user-images.githubusercontent.com/2158160/46174148-3c654780-c276-11e8-9570-00bc494d76c0.JPG)
The image above shows the anti aliasing differences.  

The images below show white text written on a white background, but with black used for the antialiasing background color to highlight the antialiased pixels.   

![old](https://user-images.githubusercontent.com/2158160/46173547-80efe380-c274-11e8-99af-2382e42d2c7e.JPG)
The image above shows text drawn directly to the TFT on the top line and text drawn on a sprite and then pushed to the TFT on the second line.

![new](https://user-images.githubusercontent.com/2158160/46173548-80efe380-c274-11e8-919b-179d77d06fdd.JPG)
The image above shows the results after making the proposed change to Sprite.cpp.
