### PR TITLE
ICST7735S red-tabbed 80x160 support

### DIFF
--- a/TFT_Drivers/ST7735_Defines.h
+++ b/TFT_Drivers/ST7735_Defines.h
@@ -16,6 +16,7 @@
 #define INITR_GREENTAB3 0x4 // Use if you get random pixels on edge(s) of 128x128 screen
 #define INITR_GREENTAB128 0x5 // Use if you only get part of 128x128 screen in rotation 0 & 1
 #define INITR_GREENTAB160x80 0x6 // Use if you only get part of 128x128 screen in rotation 0 & 1
+#define INITR_REDTAB160x80 0x7 // Added for https://www.aliexpress.com/item/ShengYang-1pcs-IPS-0-96-inch-7P-SPI-HD-65K-Full-Color-OLED-Module-ST7735-Drive/32918394604.html
 #define INITB           0xB
 
 
@@ -41,6 +42,10 @@
  
 #elif defined (ST7735_GREENTAB160x80)
   #define TAB_COLOUR INITR_GREENTAB160x80
+  #define CGRAM_OFFSET
+
+#elif defined (ST7735_REDTAB160x80)
+  #define TAB_COLOUR INITR_REDTAB160x80
   #define CGRAM_OFFSET
  
 #elif defined (ST7735_REDTAB)

--- a/TFT_Drivers/ST7735_Init.h
+++ b/TFT_Drivers/ST7735_Init.h
@@ -180,6 +180,12 @@
          colstart = 26;
          rowstart = 1;
        }
+       else if (tabcolor == INITR_REDTAB160x80)
+       {
+         commandList(Rcmd2green);
+         colstart = 24;
+         rowstart = 0;
+       }
        else if (tabcolor == INITR_REDTAB)
        {
          commandList(Rcmd2red);

--- a/TFT_Drivers/ST7735_Rotation.h
+++ b/TFT_Drivers/ST7735_Rotation.h
@@ -24,6 +24,10 @@
        writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_MH | TFT_MAD_BGR);
        colstart = 26;
        rowstart = 1;
+     } else if(tabcolor == INITR_REDTAB160x80) {
+       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_MH | TFT_MAD_BGR);
+       colstart = 24;
+       rowstart = 0;
      } else if(tabcolor == INITB) {
        writedata(TFT_MAD_MX | TFT_MAD_RGB);
      } else {
@@ -51,6 +55,10 @@
        writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_BGR);
        colstart = 1;
        rowstart = 26;
+     } else if(tabcolor == INITR_REDTAB160x80) {
+       writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_BGR);
+       colstart = 0;
+       rowstart = 24;
      } else if(tabcolor == INITB) {
        writedata(TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
      } else {
@@ -75,6 +83,10 @@
        colstart = 0;
        rowstart = 0;
      } else if(tabcolor == INITR_GREENTAB160x80) {
+       writedata(TFT_MAD_BGR);
+       colstart = 0;
+       rowstart = 0;
+     } else if(tabcolor == INITR_REDTAB160x80) {
        writedata(TFT_MAD_BGR);
        colstart = 0;
        rowstart = 0;
@@ -105,6 +117,10 @@
        writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
        colstart = 1;
        rowstart = 26;
+     } else if(tabcolor == INITR_REDTAB160x80) {
+       writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
+       colstart = 0;
+       rowstart = 24;
      } else if(tabcolor == INITB) {
        writedata(TFT_MAD_MV | TFT_MAD_RGB);
      } else {

--- a/TFT_Drivers/ST7735_Rotation.h
+++ b/TFT_Drivers/ST7735_Rotation.h
@@ -88,7 +88,7 @@
        rowstart = 0;
      } else if(tabcolor == INITR_REDTAB160x80) {
        writedata(TFT_MAD_BGR);
-       colstart = 0;
+       colstart = 24;
        rowstart = 0;
      } else if(tabcolor == INITB) {
        writedata(TFT_MAD_MY | TFT_MAD_RGB);

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -53,6 +53,7 @@
 // #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
 // #define ST7735_REDTAB
 // #define ST7735_BLACKTAB
+// #define ST7735_REDTAB160x80 // For 160 x 80 display (24 offset) (https://www.aliexpress.com/item/ShengYang-1pcs-IPS-0-96-inch-7P-SPI-HD-65K-Full-Color-OLED-Module-ST7735-Drive/32918394604.html)
 
 // ##################################################################################
 //

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -53,6 +53,7 @@
 // #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
 // #define ST7735_REDTAB
 // #define ST7735_BLACKTAB
+// #define ST7735_REDTAB160x80 // For 160 x 80 display (24 offset) (https://www.aliexpress.com/item/ShengYang-1pcs-IPS-0-96-inch-7P-SPI-HD-65K-Full-Color-OLED-Module-ST7735-Drive/32918394604.html)
 
 // ##################################################################################
 //

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "TFT_eSPI",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": "tft, ePaper, display, ESP8266, NodeMCU, ESP32, M5Stack, ILI9341, ST7735, ILI9163, S6D02A1, ILI9486, ST7789",
   "description": "A TFT and ePaper SPI graphics library for ESP8266 and ESP32",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TFT_eSPI
-version=1.1.3
+version=1.1.4
 author=Bodmer
 maintainer=Bodmer
 sentence=A fast TFT graphics library for ESP8266 and ESP32 processors for the Arduino IDE


### PR DESCRIPTION
See issue #235 for discussion.

Adds support for ICST7735S 80x160 "IPS" screen with a re-tabbed screen protector as found [on AliExpress here](https://www.aliexpress.com/item/ShengYang-1pcs-IPS-0-96-inch-7P-SPI-HD-65K-Full-Color-OLED-Module-ST7735-Drive/32918394604.html).