### PR TITLE
Add setFS function. ( Support for file systems other than SPIFFS. )

### DIFF
--- a/Extensions/Smooth_font.h
+++ b/Extensions/Smooth_font.h
@@ -41,7 +41,8 @@ fontMetrics gFont = { 0, 0, 0, 0, 0, 0, 0 };
 
   bool     fontLoaded = false; // Flags when a anti-aliased font is loaded
 
+  void setFS(fs::FS& fs) { _pFS = &fs; }
  private:
-
+  fs::FS* _pFS = NULL;
   void     loadMetrics(uint16_t gCount);
   uint32_t readInt32(void);


### PR DESCRIPTION
SmoothFont can be read from SD in the environment where SD is available like M5Stack.
(default : SPIFFS)
```
#include <SD.h>
TFT_eSPI tft = TFT_eSPI();
void setup() {
  tft.init();
  tft.setFS(SD);
  tft.loadFont("fileName");
...
```