### PR TITLE
Add new driver RM68140

### DIFF
--- a/TFT_Drivers/RM68140_Defines.h
+++ b/TFT_Drivers/RM68140_Defines.h
@@ -1,0 +1,42 @@
+// Change the width and height if required (defined in portrait mode)
+// or use the constructor to over-ride defaults
+#define TFT_WIDTH  320
+#define TFT_HEIGHT 480
+
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+
+#define TFT_RAMRD   0x2E
+
+#define TFT_MADCTL  0x36
+
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+#define TFT_MAD_MH  0x04
+#define TFT_MAD_SS  0x02
+#define TFT_MAD_GS  0x01
+
+#define TFT_IDXRD   0x00 // ILI9341 only, indexed control register read

--- a/TFT_Drivers/RM68140_Init.h
+++ b/TFT_Drivers/RM68140_Init.h
@@ -1,0 +1,77 @@
+
+// This is the command sequence that initialises the RM68140 driver
+//
+// This setup information uses simple 8 bit SPI writecommand() and writedata() functions
+//
+// See ST7735_Setup.h file for an alternative format
+
+
+// Configure RM68140 display
+
+    writecommand(TFT_SLPOUT);
+    delay(20);
+
+    writecommand(0xD0);
+    writedata(0x07);
+    writedata(0x42);
+    writedata(0x18);
+
+    writecommand(0xD1);
+    writedata(0x00);
+    writedata(0x07);
+    writedata(0x10);
+
+    writecommand(0xD2);
+    writedata(0x01);
+    writedata(0x02);
+
+    writecommand(0xC0);
+    writedata(0x10);
+    writedata(0x3B);
+    writedata(0x00);
+    writedata(0x02);
+    writedata(0x11);
+
+    writecommand(0xC5);
+    writedata(0x03);
+
+    writecommand(0xC8);
+    writedata(0x00);
+    writedata(0x32);
+    writedata(0x36);
+    writedata(0x45);
+    writedata(0x06);
+    writedata(0x16);
+    writedata(0x37);
+    writedata(0x75);
+    writedata(0x77);
+    writedata(0x54);
+    writedata(0x0C);
+    writedata(0x00);
+
+    writecommand(TFT_MADCTL);
+    writedata(0x0A);
+
+    writecommand(0x3A);
+    writedata(0x55);
+
+    writecommand(TFT_CASET);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x01);
+    writedata(0x3F);
+
+    writecommand(TFT_PASET);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x01);
+    writedata(0xDF);
+
+    delay(120);
+    writecommand(TFT_DISPON);
+
+    delay(25);
+// End of RM68140 display configuration
+
+
+

--- a/TFT_Drivers/RM68140_Rotation.h
+++ b/TFT_Drivers/RM68140_Rotation.h
@@ -1,0 +1,44 @@
+  // This is the command sequence that rotates the ILI9481 driver coordinate frame
+
+
+  writecommand(TFT_MADCTL);
+  rotation = m % 4;
+  switch (rotation) {
+   case 0: // Portrait
+     writedata(TFT_MAD_BGR);
+     writecommand(0xB6);
+     writedata(0);
+     writedata(0x22);
+     writedata(0x3B);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+     break;
+   case 1: // Landscape (Portrait + 90)
+     writedata(TFT_MAD_MV | TFT_MAD_BGR);
+     writecommand(0xB6);
+     writedata(0);
+     writedata(0x02);
+     writedata(0x3B);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+     break;
+   case 2: // Inverter portrait
+     writedata(TFT_MAD_BGR);
+     writecommand(0xB6);
+     writedata(0);
+     writedata(0x42);
+     writedata(0x3B);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+     break;
+   case 3: // Inverted landscape
+     writedata(TFT_MAD_MV | TFT_MAD_BGR);
+     writecommand(0xB6);
+     writedata(0);
+     writedata(0x62);
+     writedata(0x3B);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+     break;
+  }
+   

--- a/TFT_Drivers/RM68140_Rotation.h
+++ b/TFT_Drivers/RM68140_Rotation.h
@@ -1,4 +1,4 @@
-  // This is the command sequence that rotates the ILI9481 driver coordinate frame
+  // This is the command sequence that rotates the RM68140 driver coordinate frame
 
 
   writecommand(TFT_MADCTL);

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -412,6 +412,9 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (R61581_DRIVER)
     #include "TFT_Drivers/R61581_Init.h"
 
+#elif defined (RM68140_DRIVER)
+	#include "TFT_Drivers/RM68140_Init.h"
+
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Init.h"
 
@@ -484,6 +487,9 @@ void TFT_eSPI::setRotation(uint8_t m)
 
 #elif defined (R61581_DRIVER)
     #include "TFT_Drivers/R61581_Rotation.h"
+
+#elif defined (RM68140_DRIVER)
+	#include "TFT_Drivers/RM68140_Rotation.h"
 
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Rotation.h"
@@ -4270,7 +4276,7 @@ int16_t TFT_eSPI::drawChar(uint16_t uniCode, int32_t x, int32_t y, uint8_t font)
   {
     if ((font>2) && (font<9))
     {
-      flash_address = pgm_read_dword( (const void*)pgm_read_dword( &(fontdata[font].chartbl ) ) + uniCode*sizeof(void *) );
+      flash_address = pgm_read_dword( (const void*)(pgm_read_dword( &(fontdata[font].chartbl ) ) + uniCode*sizeof(void *)) );
       width = pgm_read_byte( (uint8_t *)pgm_read_dword( &(fontdata[font].widthtbl ) ) + uniCode );
       height= pgm_read_byte( &fontdata[font].height );
     }

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -28,6 +28,7 @@
 //#define ST7789_DRIVER      // Full configuration option, define additional parameters below for this display
 //#define ST7789_2_DRIVER    // Minimal configuration option, define additional parameters below for this display
 //#define R61581_DRIVER
+//#define RM68140_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -41,6 +41,8 @@
 //#include <User_Setups/Setup17_ePaper.h>            // Setup file for any Waveshare ePaper display
 //#include <User_Setups/Setup18_ST7789.h>            // Setup file configured for ST7789
 
+//#include <User_Setups/Setup19_RM68140_Parallel.h>	 // Setup file configured for RM68140 with parallel bus
+
 //#include <User_Setups/Setup20_ILI9488.h>           // Setup file for ESP8266 and ILI9488 SPI bus TFT
 //#include <User_Setups/Setup21_ILI9488.h>           // Setup file for ESP32 and ILI9488 SPI bus TFT
 
@@ -110,6 +112,9 @@
 #elif defined (ST7789_2_DRIVER)
      #include "TFT_Drivers/ST7789_2_Defines.h"
      #define  TFT_DRIVER 0x778B
+#elif defined (RM68140_DRIVER)
+	 #include "TFT_Drivers/RM68140_Defines.h"
+	 #define  TFT_DRIVER 0x6814
 #elif defined (XYZZY_DRIVER)  // <<<<<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVER HERE
      #include "TFT_Drivers/XYZZY_Defines.h"
      #define  TFT_DRIVER 0x0000

--- a/User_Setups/Setup19_RM68140_Parallel.h
+++ b/User_Setups/Setup19_RM68140_Parallel.h
@@ -1,0 +1,35 @@
+// See SetupX_Template.h for all options available
+
+#define ESP32_PARALLEL
+
+
+#define RM68140_DRIVER
+
+
+// ESP32 pins used for UNO format board
+#define TFT_CS   33  // Chip select control pin
+#define TFT_DC   15  // Data Command control pin - must use a pin in the range 0-31
+#define TFT_RST  32  // Reset pin
+
+#define TFT_WR    4  // Write strobe control pin - must use a pin in the range 0-31
+#define TFT_RD    2
+
+#define TFT_D0   12  // Must use pins in the range 0-31 for the data bus
+#define TFT_D1   13  // so a single register write sets/clears all bits
+#define TFT_D2   26
+#define TFT_D3   25
+#define TFT_D4   17
+#define TFT_D5   16
+#define TFT_D6   27
+#define TFT_D7   14
+
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT


### PR DESCRIPTION
- Added new RM68140 480x320 TFT. It works like ILI9481 but needed some changes to make setRotation() work properly.
- Fixed some PlatformIO warnings