### PR TITLE
I get a white screen only running the TFT_Print_Test and other examples

### DIFF
--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -128,7 +128,7 @@
   #define DC_C // No macro allocated so it generates no code
   #define DC_D // No macro allocated so it generates no code
 #else
-  #if defined (ESP8266) && (TFT_DC == 16)
+#if defined (ESP8266) && (TFT_DC == D0)
     #define DC_C digitalWrite(TFT_DC, LOW)
     #define DC_D digitalWrite(TFT_DC, HIGH)
   #elif defined (ESP32)
@@ -185,7 +185,7 @@
   #define CS_L // No macro allocated so it generates no code
   #define CS_H // No macro allocated so it generates no code
 #else
-  #if defined (ESP8266) && (TFT_CS == 16)
+#if defined (ESP8266) && (TFT_CS == D0)
     #define CS_L digitalWrite(TFT_CS, LOW)
     #define CS_H digitalWrite(TFT_CS, HIGH)
   #elif defined (ESP32)


### PR DESCRIPTION
I'm running an authentic Wemos D1 mini (ESP8266), and the Wemos TFT 2.4 Touch Shield ( https://wiki.wemos.cc/products:d1_mini_shields:tft_2.4_shield ) which is ILI9341 driver.

Trying all the TFT_eSPI examples, I get just a white screen on the display. (The same display unit does work with an ESP32, the Wemos D32 Pro.)

This fix makes the Print Test (and other examples such as Pong, and Cellular Automata, at 320x240) work on this hardware setup.

BTW my User_Setup.h has:
```
#ifdef ESP8266
  #define TFT_CS   D0  // TFT Chip select control pin (library pulls permanently low                            
  #define TFT_DC   D8  // TFT Data Command control pin - must use a pin in the range 0-31                       
  #define TFT_BL   -1  // TFT backlight control pin, aka TFT_LED                                                
  #define TFT_RST  -1  // TFT Reset pin, toggles on startup                                                     
  #define TOUCH_CS D3  // Touch Screen Chip Select, aka TS_CS                                                   
#endif
```


