### PR TITLE
Add: Destructor of TFT_eSprite.

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -92,6 +92,16 @@ void* TFT_eSprite::createSprite(int16_t w, int16_t h, uint8_t frames)
 
 
 /***************************************************************************************
+** Function name:           ~TFT_eSprite
+** Description:             Class destructor
+*************************************************************************************x*/
+TFT_eSprite::~TFT_eSprite()
+{
+  deleteSprite();
+}
+
+
+/***************************************************************************************
 ** Function name:           callocSprite
 ** Description:             Allocate a memory area for the Sprite and return pointer
 *************************************************************************************x*/

--- a/Extensions/Sprite.h
+++ b/Extensions/Sprite.h
@@ -10,6 +10,7 @@ class TFT_eSprite : public TFT_eSPI {
  public:
 
   TFT_eSprite(TFT_eSPI *tft);
+  virtual ~TFT_eSprite();
 
            // Create a sprite of width x height pixels, return a pointer to the RAM area
            // Sketch can cast returned value to (uint16_t*) for 16 bit depth if needed


### PR DESCRIPTION
This prevents memory leaks if the user forgets to call deleteSprite.