### PR TITLE
Fix: freefont vertical offset with print function.

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -1447,8 +1447,12 @@ size_t TFT_eSprite::write(uint8_t utf8)
           this->cursor_x  = 0;
           this->cursor_y += (int16_t)textsize * (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         }
-        if (textwrapY && (this->cursor_y >= _iheight)) this->cursor_y = 0;
-        drawChar(this->cursor_x, this->cursor_y, uniCode, textcolor, textbgcolor, textsize);
+        int32_t y = this->cursor_y + glyph_ab * textsize; // Adjust for baseline datum of free fonts
+        if (textwrapY && (y >= (int32_t)_iheight)) {
+          this->cursor_y = 0;
+          y = glyph_ab * textsize;
+        }
+        drawChar(this->cursor_x, y, uniCode, textcolor, textbgcolor, textsize);
       }
       this->cursor_x += pgm_read_byte(&glyph->xAdvance) * (int16_t)textsize;
     }

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -4222,8 +4222,12 @@ size_t TFT_eSPI::write(uint8_t utf8)
           cursor_y += (int16_t)textsize *
                       (uint8_t)pgm_read_byte(&gfxFont->yAdvance);
         }
-        if (textwrapY && (cursor_y >= (int32_t)_height)) cursor_y = 0;
-        drawChar(cursor_x, cursor_y, uniCode, textcolor, textbgcolor, textsize);
+        int32_t y = cursor_y + glyph_ab * textsize;
+        if (textwrapY && (y >= (int32_t)_height)) {
+          cursor_y = 0;
+          y = glyph_ab * textsize;
+        }
+        drawChar(cursor_x, y, uniCode, textcolor, textbgcolor, textsize);
       }
       cursor_x += pgm_read_byte(&glyph->xAdvance) * (int16_t)textsize;
     }


### PR DESCRIPTION
When the print function is used with a free font, the vertical offset shifts.

![image](https://user-images.githubusercontent.com/42724151/69391585-a8c2c600-0d16-11ea-9fba-8d4a8dc188b4.png)

test code.
    Tft.setTextFont(0);
    Tft.print("8");
    Tft.setTextFont(2);
    Tft.print("8");
    Tft.setFreeFont(&FreeSansBoldOblique9pt7b);
    Tft.print("8");
    Tft.setTextFont(4);
    Tft.print("8");
    Tft.setFreeFont(&FreeSansBoldOblique12pt7b);
    Tft.print("8");
    Tft.setFreeFont(&FreeSansBoldOblique18pt7b);
    Tft.print("8");
    Tft.setTextFont(6);
    Tft.print("8");
    Tft.setFreeFont(&FreeSansBoldOblique24pt7b);
    Tft.print("8");
    Tft.setTextFont(7);
    Tft.print("8");
    Tft.setTextFont(8);
    Tft.print("8");
