### PR TITLE
Fix json syntax

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,19 +1,17 @@
 {
   "name": "TFT_eSPI",
   "version": "1.5.0",
-  "keywords": "Arduino", "tft, ePaper, display, STM32, ESP8266, NodeMCU, ESP32, M5Stack, ILI9341, ST7735, ILI9163, S6D02A1, ILI9486, ST7789, RM68140",
+  "keywords": "Arduino, tft, ePaper, display, STM32, ESP8266, NodeMCU, ESP32, M5Stack, ILI9341, ST7735, ILI9163, S6D02A1, ILI9486, ST7789, RM68140",
   "description": "A TFT and ePaper SPI graphics library with optimisation for ESP8266, ESP32 and STM32",
-  "repository":
-  {
+  "repository": {
     "type": "git",
     "url": "https://github.com/Bodmer/TFT_eSPI"
   },
-  "authors":
-  [
+  "authors": [
     {
-        "name": "Bodmer",
-        "email": "bodmer@anola.net",
-        "maintainer": true
+      "name": "Bodmer",
+      "email": "bodmer@anola.net",
+      "maintainer": true
     }
   ],
   "frameworks": "arduino",


### PR DESCRIPTION
Build fails when trying to compile with PlatformIO due to this malformed JSON