### PR TITLE
add touch rotation function

### DIFF
--- a/Extensions/Touch.cpp
+++ b/Extensions/Touch.cpp
@@ -15,14 +15,17 @@
 ** Description:             Start transaction and select touch controller
 ***************************************************************************************/
 // The touch controller has a low SPI clock rate
-inline void TFT_eSPI::begin_touch_read_write(void){
+inline void TFT_eSPI::begin_touch_read_write(void) {
   DMA_BUSY_CHECK;
-  CS_H; // Just in case it has been left low
-  #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS)
-    if (locked) {locked = false; spi.beginTransaction(SPISettings(SPI_TOUCH_FREQUENCY, MSBFIRST, SPI_MODE0));}
-  #else
-    spi.setFrequency(SPI_TOUCH_FREQUENCY);
-  #endif
+  CS_H;  // Just in case it has been left low
+#if defined(SPI_HAS_TRANSACTION) && defined(SUPPORT_TRANSACTIONS)
+  if (locked) {
+    locked = false;
+    spi.beginTransaction(SPISettings(SPI_TOUCH_FREQUENCY, MSBFIRST, SPI_MODE0));
+  }
+#else
+  spi.setFrequency(SPI_TOUCH_FREQUENCY);
+#endif
   SET_BUS_READ_MODE;
   T_CS_L;
 }
@@ -31,13 +34,18 @@ inline void TFT_eSPI::begin_touch_read_write(void){
 ** Function name:           end_touch_read_write - was spi_end_touch
 ** Description:             End transaction and deselect touch controller
 ***************************************************************************************/
-inline void TFT_eSPI::end_touch_read_write(void){
+inline void TFT_eSPI::end_touch_read_write(void) {
   T_CS_H;
-  #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS)
-    if(!inTransaction) {if (!locked) {locked = true; spi.endTransaction();}}
-  #else
-    spi.setFrequency(SPI_FREQUENCY);
-  #endif
+#if defined(SPI_HAS_TRANSACTION) && defined(SUPPORT_TRANSACTIONS)
+  if (!inTransaction) {
+    if (!locked) {
+      locked = true;
+      spi.endTransaction();
+    }
+  }
+#else
+  spi.setFrequency(SPI_FREQUENCY);
+#endif
   SET_BUS_WRITE_MODE;
 }
 
@@ -45,58 +53,79 @@ inline void TFT_eSPI::end_touch_read_write(void){
 ** Function name:           Legacy - deprecated
 ** Description:             Start/end transaction
 ***************************************************************************************/
-void TFT_eSPI::spi_begin_touch() {begin_touch_read_write();}
-void TFT_eSPI::spi_end_touch()   {  end_touch_read_write();}
-
+void TFT_eSPI::spi_begin_touch() {
+  begin_touch_read_write();
+}
+void TFT_eSPI::spi_end_touch() {
+  end_touch_read_write();
+}
+void TFT_eSPI::set_touch_rotation(uint8_t rotation) {
+  _rotation = rotation;
+}
 /***************************************************************************************
 ** Function name:           getTouchRaw
 ** Description:             read raw touch position.  Always returns true.
 ***************************************************************************************/
-uint8_t TFT_eSPI::getTouchRaw(uint16_t *x, uint16_t *y){
-  uint16_t tmp;
+uint8_t TFT_eSPI::getTouchRaw(uint16_t* x, uint16_t* y) {
+  uint16_t tmp1, tmp2;
 
   begin_touch_read_write();
-  
+
   // Start YP sample request for x position, read 4 times and keep last sample
-  spi.transfer(0xd0);                    // Start new YP conversion
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0xd0);                    // Read last 8 bits and start new YP conversion
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0xd0);                    // Read last 8 bits and start new YP conversion
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0xd0);                    // Read last 8 bits and start new YP conversion
+  spi.transfer(0xd0);  // Start new YP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion
 
-  tmp = spi.transfer(0);                   // Read first 8 bits
-  tmp = tmp <<5;
-  tmp |= 0x1f & (spi.transfer(0x90)>>3);   // Read last 8 bits and start new XP conversion
+  tmp1 = spi.transfer(0);  // Read first 8 bits
+  tmp1 = tmp1 << 5;
+  tmp1 |= 0x1f & (spi.transfer(0x90) >> 3);  // Read last 8 bits and start new XP conversion
 
-  *x = tmp;
+  //*x = tmp;
 
   // Start XP sample request for y position, read 4 times and keep last sample
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0x90);                    // Read last 8 bits and start new XP conversion
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0x90);                    // Read last 8 bits and start new XP conversion
-  spi.transfer(0);                       // Read first 8 bits
-  spi.transfer(0x90);                    // Read last 8 bits and start new XP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion
+  spi.transfer(0);     // Read first 8 bits
+  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion
 
-  tmp = spi.transfer(0);                 // Read first 8 bits
-  tmp = tmp <<5;
-  tmp |= 0x1f & (spi.transfer(0)>>3);    // Read last 8 bits
+  tmp2 = spi.transfer(0);  // Read first 8 bits
+  tmp2 = tmp2 << 5;
+  tmp2 |= 0x1f & (spi.transfer(0) >> 3);  // Read last 8 bits
 
-  *y = tmp;
+  //*y = tmp;
 
+  switch (_rotation) {
+    case 0:
+      *x = 4095 - tmp2;
+      *y = tmp1;
+      break;
+    case 1:
+      *x = tmp1;
+      *y = tmp2;
+      break;
+    case 2:
+      *x = tmp2;
+      *y = 4095 - tmp1;
+      break;
+    default:  // 3
+      *x = 4095 - tmp1;
+      *y = 4095 - tmp2;
+  }
   end_touch_read_write();
-
   return true;
 }
 
 /***************************************************************************************
 ** Function name:           getTouchRawZ
-** Description:             read raw pressure on touchpad and return Z value. 
+** Description:             read raw pressure on touchpad and return Z value.
 ***************************************************************************************/
-uint16_t TFT_eSPI::getTouchRawZ(void){
-
+uint16_t TFT_eSPI::getTouchRawZ(void) {
   begin_touch_read_write();
 
   // Z sample request
@@ -107,22 +136,21 @@ uint16_t TFT_eSPI::getTouchRawZ(void){
 
   end_touch_read_write();
 
-  return (uint16_t)tz;
+  return (uint16_t) tz;
 }
 
 /***************************************************************************************
 ** Function name:           validTouch
-** Description:             read validated position. Return false if not pressed. 
+** Description:             read validated position. Return false if not pressed.
 ***************************************************************************************/
-#define _RAWERR 20 // Deadband error allowed in successive position samples
-uint8_t TFT_eSPI::validTouch(uint16_t *x, uint16_t *y, uint16_t threshold){
+#define _RAWERR 20  // Deadband error allowed in successive position samples
+uint8_t TFT_eSPI::validTouch(uint16_t* x, uint16_t* y, uint16_t threshold) {
   uint16_t x_tmp, y_tmp, x_tmp2, y_tmp2;
 
   // Wait until pressure stops increasing to debounce pressure
   uint16_t z1 = 1;
   uint16_t z2 = 0;
-  while (z1 > z2)
-  {
+  while (z1 > z2) {
     z2 = z1;
     z1 = getTouchRawZ();
     delay(1);
@@ -130,56 +158,67 @@ uint8_t TFT_eSPI::validTouch(uint16_t *x, uint16_t *y, uint16_t threshold){
 
   //  Serial.print("Z = ");Serial.println(z1);
 
-  if (z1 <= threshold) return false;
-    
-  getTouchRaw(&x_tmp,&y_tmp);
+  if (z1 <= threshold)
+    return false;
+
+  getTouchRaw(&x_tmp, &y_tmp);
 
   //  Serial.print("Sample 1 x,y = "); Serial.print(x_tmp);Serial.print(",");Serial.print(y_tmp);
   //  Serial.print(", Z = ");Serial.println(z1);
 
-  delay(1); // Small delay to the next sample
-  if (getTouchRawZ() <= threshold) return false;
+  delay(1);  // Small delay to the next sample
+  if (getTouchRawZ() <= threshold)
+    return false;
 
-  delay(2); // Small delay to the next sample
-  getTouchRaw(&x_tmp2,&y_tmp2);
-  
+  delay(2);  // Small delay to the next sample
+  getTouchRaw(&x_tmp2, &y_tmp2);
+
   //  Serial.print("Sample 2 x,y = "); Serial.print(x_tmp2);Serial.print(",");Serial.println(y_tmp2);
   //  Serial.print("Sample difference = ");Serial.print(abs(x_tmp - x_tmp2));Serial.print(",");Serial.println(abs(y_tmp - y_tmp2));
 
-  if (abs(x_tmp - x_tmp2) > _RAWERR) return false;
-  if (abs(y_tmp - y_tmp2) > _RAWERR) return false;
-  
+  if (abs(x_tmp - x_tmp2) > _RAWERR)
+    return false;
+  if (abs(y_tmp - y_tmp2) > _RAWERR)
+    return false;
+
   *x = x_tmp;
   *y = y_tmp;
-  
+
   return true;
 }
-  
+
 /***************************************************************************************
 ** Function name:           getTouch
-** Description:             read callibrated position. Return false if not pressed. 
+** Description:             read callibrated position. Return false if not pressed.
 ***************************************************************************************/
-#define Z_THRESHOLD 350 // Touch pressure threshold for validating touches
-uint8_t TFT_eSPI::getTouch(uint16_t *x, uint16_t *y, uint16_t threshold){
+#define Z_THRESHOLD 350  // Touch pressure threshold for validating touches
+uint8_t TFT_eSPI::getTouch(uint16_t* x, uint16_t* y, uint16_t threshold) {
   uint16_t x_tmp, y_tmp;
-  
-  if (threshold<20) threshold = 20;
-  if (_pressTime > millis()) threshold=20;
+
+  if (threshold < 20)
+    threshold = 20;
+  if (_pressTime > millis())
+    threshold = 20;
 
   uint8_t n = 5;
   uint8_t valid = 0;
-  while (n--)
-  {
-    if (validTouch(&x_tmp, &y_tmp, threshold)) valid++;;
+  while (n--) {
+    if (validTouch(&x_tmp, &y_tmp, threshold))
+      valid++;
+    ;
   }
 
-  if (valid<1) { _pressTime = 0; return false; }
-  
+  if (valid < 1) {
+    _pressTime = 0;
+    return false;
+  }
+
   _pressTime = millis() + 50;
 
   convertRawXY(&x_tmp, &y_tmp);
 
-  if (x_tmp >= _width || y_tmp >= _height) return false;
+  if (x_tmp >= _width || y_tmp >= _height)
+    return false;
 
   _pressX = x_tmp;
   _pressY = y_tmp;
@@ -190,25 +229,24 @@ uint8_t TFT_eSPI::getTouch(uint16_t *x, uint16_t *y, uint16_t threshold){
 
 /***************************************************************************************
 ** Function name:           convertRawXY
-** Description:             convert raw touch x,y values to screen coordinates 
+** Description:             convert raw touch x,y values to screen coordinates
 ***************************************************************************************/
-void TFT_eSPI::convertRawXY(uint16_t *x, uint16_t *y)
-{
+void TFT_eSPI::convertRawXY(uint16_t* x, uint16_t* y) {
   uint16_t x_tmp = *x, y_tmp = *y, xx, yy;
 
-  if(!touchCalibration_rotate){
-    xx=(x_tmp-touchCalibration_x0)*_width/touchCalibration_x1;
-    yy=(y_tmp-touchCalibration_y0)*_height/touchCalibration_y1;
-    if(touchCalibration_invert_x)
+  if (!touchCalibration_rotate) {
+    xx = (x_tmp - touchCalibration_x0) * _width / touchCalibration_x1;
+    yy = (y_tmp - touchCalibration_y0) * _height / touchCalibration_y1;
+    if (touchCalibration_invert_x)
       xx = _width - xx;
-    if(touchCalibration_invert_y)
+    if (touchCalibration_invert_y)
       yy = _height - yy;
   } else {
-    xx=(y_tmp-touchCalibration_x0)*_width/touchCalibration_x1;
-    yy=(x_tmp-touchCalibration_y0)*_height/touchCalibration_y1;
-    if(touchCalibration_invert_x)
+    xx = (y_tmp - touchCalibration_x0) * _width / touchCalibration_x1;
+    yy = (x_tmp - touchCalibration_y0) * _height / touchCalibration_y1;
+    if (touchCalibration_invert_x)
       xx = _width - xx;
-    if(touchCalibration_invert_y)
+    if (touchCalibration_invert_y)
       yy = _height - yy;
   }
   *x = xx;
@@ -217,86 +255,86 @@ void TFT_eSPI::convertRawXY(uint16_t *x, uint16_t *y)
 
 /***************************************************************************************
 ** Function name:           calibrateTouch
-** Description:             generates calibration parameters for touchscreen. 
+** Description:             generates calibration parameters for touchscreen.
 ***************************************************************************************/
-void TFT_eSPI::calibrateTouch(uint16_t *parameters, uint32_t color_fg, uint32_t color_bg, uint8_t size){
-  int16_t values[] = {0,0,0,0,0,0,0,0};
+void TFT_eSPI::calibrateTouch(uint16_t* parameters, uint32_t color_fg, uint32_t color_bg, uint8_t size) {
+  int16_t values[] = {0, 0, 0, 0, 0, 0, 0, 0};
   uint16_t x_tmp, y_tmp;
 
+  for (uint8_t i = 0; i < 4; i++) {
+    fillRect(0, 0, size + 1, size + 1, color_bg);
+    fillRect(0, _height - size - 1, size + 1, size + 1, color_bg);
+    fillRect(_width - size - 1, 0, size + 1, size + 1, color_bg);
+    fillRect(_width - size - 1, _height - size - 1, size + 1, size + 1, color_bg);
 
+    if (i == 5)
+      break;  // used to clear the arrows
 
-  for(uint8_t i = 0; i<4; i++){
-    fillRect(0, 0, size+1, size+1, color_bg);
-    fillRect(0, _height-size-1, size+1, size+1, color_bg);
-    fillRect(_width-size-1, 0, size+1, size+1, color_bg);
-    fillRect(_width-size-1, _height-size-1, size+1, size+1, color_bg);
-
-    if (i == 5) break; // used to clear the arrows
-    
     switch (i) {
-      case 0: // up left
+      case 0:  // up left
         drawLine(0, 0, 0, size, color_fg);
         drawLine(0, 0, size, 0, color_fg);
-        drawLine(0, 0, size , size, color_fg);
+        drawLine(0, 0, size, size, color_fg);
         break;
-      case 1: // bot left
-        drawLine(0, _height-size-1, 0, _height-1, color_fg);
-        drawLine(0, _height-1, size, _height-1, color_fg);
-        drawLine(size, _height-size-1, 0, _height-1 , color_fg);
+      case 1:  // bot left
+        drawLine(0, _height - size - 1, 0, _height - 1, color_fg);
+        drawLine(0, _height - 1, size, _height - 1, color_fg);
+        drawLine(size, _height - size - 1, 0, _height - 1, color_fg);
         break;
-      case 2: // up right
-        drawLine(_width-size-1, 0, _width-1, 0, color_fg);
-        drawLine(_width-size-1, size, _width-1, 0, color_fg);
-        drawLine(_width-1, size, _width-1, 0, color_fg);
+      case 2:  // up right
+        drawLine(_width - size - 1, 0, _width - 1, 0, color_fg);
+        drawLine(_width - size - 1, size, _width - 1, 0, color_fg);
+        drawLine(_width - 1, size, _width - 1, 0, color_fg);
         break;
-      case 3: // bot right
-        drawLine(_width-size-1, _height-size-1, _width-1, _height-1, color_fg);
-        drawLine(_width-1, _height-1-size, _width-1, _height-1, color_fg);
-        drawLine(_width-1-size, _height-1, _width-1, _height-1, color_fg);
+      case 3:  // bot right
+        drawLine(_width - size - 1, _height - size - 1, _width - 1, _height - 1, color_fg);
+        drawLine(_width - 1, _height - 1 - size, _width - 1, _height - 1, color_fg);
+        drawLine(_width - 1 - size, _height - 1, _width - 1, _height - 1, color_fg);
         break;
-      }
+    }
 
     // user has to get the chance to release
-    if(i>0) delay(1000);
+    if (i > 0)
+      delay(1000);
 
-    for(uint8_t j= 0; j<8; j++){
+    for (uint8_t j = 0; j < 8; j++) {
       // Use a lower detect threshold as corners tend to be less sensitive
-      while(!validTouch(&x_tmp, &y_tmp, Z_THRESHOLD/2));
-      values[i*2  ] += x_tmp;
-      values[i*2+1] += y_tmp;
-      }
-    values[i*2  ] /= 8;
-    values[i*2+1] /= 8;
+      while (!validTouch(&x_tmp, &y_tmp, Z_THRESHOLD / 2))
+        ;
+      values[i * 2] += x_tmp;
+      values[i * 2 + 1] += y_tmp;
+    }
+    values[i * 2] /= 8;
+    values[i * 2 + 1] /= 8;
   }
 
-
-  // from case 0 to case 1, the y value changed. 
+  // from case 0 to case 1, the y value changed.
   // If the measured delta of the touch x axis is bigger than the delta of the y axis, the touch and TFT axes are switched.
   touchCalibration_rotate = false;
-  if(abs(values[0]-values[2]) > abs(values[1]-values[3])){
+  if (abs(values[0] - values[2]) > abs(values[1] - values[3])) {
     touchCalibration_rotate = true;
-    touchCalibration_x0 = (values[1] + values[3])/2; // calc min x
-    touchCalibration_x1 = (values[5] + values[7])/2; // calc max x
-    touchCalibration_y0 = (values[0] + values[4])/2; // calc min y
-    touchCalibration_y1 = (values[2] + values[6])/2; // calc max y
+    touchCalibration_x0 = (values[1] + values[3]) / 2;  // calc min x
+    touchCalibration_x1 = (values[5] + values[7]) / 2;  // calc max x
+    touchCalibration_y0 = (values[0] + values[4]) / 2;  // calc min y
+    touchCalibration_y1 = (values[2] + values[6]) / 2;  // calc max y
   } else {
-    touchCalibration_x0 = (values[0] + values[2])/2; // calc min x
-    touchCalibration_x1 = (values[4] + values[6])/2; // calc max x
-    touchCalibration_y0 = (values[1] + values[5])/2; // calc min y
-    touchCalibration_y1 = (values[3] + values[7])/2; // calc max y
+    touchCalibration_x0 = (values[0] + values[2]) / 2;  // calc min x
+    touchCalibration_x1 = (values[4] + values[6]) / 2;  // calc max x
+    touchCalibration_y0 = (values[1] + values[5]) / 2;  // calc min y
+    touchCalibration_y1 = (values[3] + values[7]) / 2;  // calc max y
   }
 
   // in addition, the touch screen axis could be in the opposite direction of the TFT axis
   touchCalibration_invert_x = false;
-  if(touchCalibration_x0 > touchCalibration_x1){
-    values[0]=touchCalibration_x0;
+  if (touchCalibration_x0 > touchCalibration_x1) {
+    values[0] = touchCalibration_x0;
     touchCalibration_x0 = touchCalibration_x1;
     touchCalibration_x1 = values[0];
     touchCalibration_invert_x = true;
   }
   touchCalibration_invert_y = false;
-  if(touchCalibration_y0 > touchCalibration_y1){
-    values[0]=touchCalibration_y0;
+  if (touchCalibration_y0 > touchCalibration_y1) {
+    values[0] = touchCalibration_y0;
     touchCalibration_y0 = touchCalibration_y1;
     touchCalibration_y1 = values[0];
     touchCalibration_invert_y = true;
@@ -306,36 +344,43 @@ void TFT_eSPI::calibrateTouch(uint16_t *parameters, uint32_t color_fg, uint32_t 
   touchCalibration_x1 -= touchCalibration_x0;
   touchCalibration_y1 -= touchCalibration_y0;
 
-  if(touchCalibration_x0 == 0) touchCalibration_x0 = 1;
-  if(touchCalibration_x1 == 0) touchCalibration_x1 = 1;
-  if(touchCalibration_y0 == 0) touchCalibration_y0 = 1;
-  if(touchCalibration_y1 == 0) touchCalibration_y1 = 1;
+  if (touchCalibration_x0 == 0)
+    touchCalibration_x0 = 1;
+  if (touchCalibration_x1 == 0)
+    touchCalibration_x1 = 1;
+  if (touchCalibration_y0 == 0)
+    touchCalibration_y0 = 1;
+  if (touchCalibration_y1 == 0)
+    touchCalibration_y1 = 1;
 
   // export parameters, if pointer valid
-  if(parameters != NULL){
+  if (parameters != NULL) {
     parameters[0] = touchCalibration_x0;
     parameters[1] = touchCalibration_x1;
     parameters[2] = touchCalibration_y0;
     parameters[3] = touchCalibration_y1;
-    parameters[4] = touchCalibration_rotate | (touchCalibration_invert_x <<1) | (touchCalibration_invert_y <<2);
+    parameters[4] = touchCalibration_rotate | (touchCalibration_invert_x << 1) | (touchCalibration_invert_y << 2);
   }
 }
 
-
 /***************************************************************************************
 ** Function name:           setTouch
-** Description:             imports calibration parameters for touchscreen. 
+** Description:             imports calibration parameters for touchscreen.
 ***************************************************************************************/
-void TFT_eSPI::setTouch(uint16_t *parameters){
+void TFT_eSPI::setTouch(uint16_t* parameters) {
   touchCalibration_x0 = parameters[0];
   touchCalibration_x1 = parameters[1];
   touchCalibration_y0 = parameters[2];
   touchCalibration_y1 = parameters[3];
 
-  if(touchCalibration_x0 == 0) touchCalibration_x0 = 1;
-  if(touchCalibration_x1 == 0) touchCalibration_x1 = 1;
-  if(touchCalibration_y0 == 0) touchCalibration_y0 = 1;
-  if(touchCalibration_y1 == 0) touchCalibration_y1 = 1;
+  if (touchCalibration_x0 == 0)
+    touchCalibration_x0 = 1;
+  if (touchCalibration_x1 == 0)
+    touchCalibration_x1 = 1;
+  if (touchCalibration_y0 == 0)
+    touchCalibration_y0 = 1;
+  if (touchCalibration_y1 == 0)
+    touchCalibration_y1 = 1;
 
   touchCalibration_rotate = parameters[4] & 0x01;
   touchCalibration_invert_x = parameters[4] & 0x02;

--- a/Extensions/Touch.h
+++ b/Extensions/Touch.h
@@ -1,37 +1,44 @@
- // Coded by Bodmer 10/2/18, see license in root directory.
- // This is part of the TFT_eSPI class and is associated with the Touch Screen handlers
+/*
+ * @Date: 2020-07-23 12:53:53
+ * @LastEditors: xfdr0805
+ * @LastEditTime: 2020-07-23 13:04:02
+ * @FilePath: \ESP8266_Weather_Station_Color\.pio\libdeps\esp12e\TFT_eSPI\Extensions\Touch.h
+ */
+// Coded by Bodmer 10/2/18, see license in root directory.
+// This is part of the TFT_eSPI class and is associated with the Touch Screen handlers
 
- public:
-           // Get raw x,y ADC values from touch controller
-  uint8_t  getTouchRaw(uint16_t *x, uint16_t *y);
-           // Get raw z (i.e. pressure) ADC value from touch controller
-  uint16_t getTouchRawZ(void);
-           // Convert raw x,y values to calibrated and correctly rotated screen coordinates
-  void     convertRawXY(uint16_t *x, uint16_t *y);
-           // Get the screen touch coordinates, returns true if screen has been touched
-           // if the touch cordinates are off screen then x and y are not updated
-  uint8_t  getTouch(uint16_t *x, uint16_t *y, uint16_t threshold = 600);
+public:
+// Get raw x,y ADC values from touch controller
+uint8_t getTouchRaw(uint16_t* x, uint16_t* y);
+// Get raw z (i.e. pressure) ADC value from touch controller
+uint16_t getTouchRawZ(void);
+// Convert raw x,y values to calibrated and correctly rotated screen coordinates
+void convertRawXY(uint16_t* x, uint16_t* y);
+// Get the screen touch coordinates, returns true if screen has been touched
+// if the touch cordinates are off screen then x and y are not updated
+uint8_t getTouch(uint16_t* x, uint16_t* y, uint16_t threshold = 600);
 
-           // Run screen calibration and test, report calibration values to the serial port
-  void     calibrateTouch(uint16_t *data, uint32_t color_fg, uint32_t color_bg, uint8_t size);
-           // Set the screen calibration values
-  void     setTouch(uint16_t *data);
+// Run screen calibration and test, report calibration values to the serial port
+void calibrateTouch(uint16_t* data, uint32_t color_fg, uint32_t color_bg, uint8_t size);
+// Set the screen calibration values
+void setTouch(uint16_t* data);
+void set_touch_rotation(uint8_t rotation);
 
- private:
-           // Legacy support only - deprecated TODO: delete
-  void     spi_begin_touch();
-  void     spi_end_touch();
+private:
+// Legacy support only - deprecated TODO: delete
+void spi_begin_touch();
+void spi_end_touch();
 
-           // Handlers for the touch controller bus settings
-  inline void begin_touch_read_write() __attribute__((always_inline));
-  inline void end_touch_read_write()   __attribute__((always_inline));
+// Handlers for the touch controller bus settings
+inline void begin_touch_read_write() __attribute__((always_inline));
+inline void end_touch_read_write() __attribute__((always_inline));
 
-           // Private function to validate a touch, allow settle time and reduce spurious coordinates
-  uint8_t  validTouch(uint16_t *x, uint16_t *y, uint16_t threshold = 600);
+// Private function to validate a touch, allow settle time and reduce spurious coordinates
+uint8_t validTouch(uint16_t* x, uint16_t* y, uint16_t threshold = 600);
 
-           // Initialise with example calibration values so processor does not crash if setTouch() not called in setup()
-  uint16_t touchCalibration_x0 = 300, touchCalibration_x1 = 3600, touchCalibration_y0 = 300, touchCalibration_y1 = 3600;
-  uint8_t  touchCalibration_rotate = 1, touchCalibration_invert_x = 2, touchCalibration_invert_y = 0;
-
-  uint32_t _pressTime;        // Press and hold time-out
-  uint16_t _pressX, _pressY;  // For future use (last sampled calibrated coordinates)
+// Initialise with example calibration values so processor does not crash if setTouch() not called in setup()
+uint16_t touchCalibration_x0 = 300, touchCalibration_x1 = 3600, touchCalibration_y0 = 300, touchCalibration_y1 = 3600;
+uint8_t touchCalibration_rotate = 1, touchCalibration_invert_x = 2, touchCalibration_invert_y = 0;
+uint8_t _rotation = 0;      //
+uint32_t _pressTime;        // Press and hold time-out
+uint16_t _pressX, _pressY;  // For future use (last sampled calibrated coordinates)


### PR DESCRIPTION
test ok in my project
The code has been formatted and is inconsistent with the original one. The following is the modification

touch.cpp

void TFT_eSPI::set_touch_rotation(uint8_t rotation) {
  _rotation = rotation;
}
/***************************************************************************************
** Function name:           getTouchRaw
** Description:             read raw touch position.  Always returns true.
***************************************************************************************/
uint8_t TFT_eSPI::getTouchRaw(uint16_t* x, uint16_t* y) {
  uint16_t tmp1, tmp2;

  begin_touch_read_write();

  // Start YP sample request for x position, read 4 times and keep last sample
  spi.transfer(0xd0);  // Start new YP conversion
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0xd0);  // Read last 8 bits and start new YP conversion

  tmp1 = spi.transfer(0);  // Read first 8 bits
  tmp1 = tmp1 << 5;
  tmp1 |= 0x1f & (spi.transfer(0x90) >> 3);  // Read last 8 bits and start new XP conversion

  //*x = tmp;

  // Start XP sample request for y position, read 4 times and keep last sample
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion
  spi.transfer(0);     // Read first 8 bits
  spi.transfer(0x90);  // Read last 8 bits and start new XP conversion

  tmp2 = spi.transfer(0);  // Read first 8 bits
  tmp2 = tmp2 << 5;
  tmp2 |= 0x1f & (spi.transfer(0) >> 3);  // Read last 8 bits

  //*y = tmp;

  switch (_rotation) {
    case 0:
      *x = 4095 - tmp2;
      *y = tmp1;
      break;
    case 1:
      *x = tmp1;
      *y = tmp2;
      break;
    case 2:
      *x = tmp2;
      *y = 4095 - tmp1;
      break;
    default:  // 3
      *x = 4095 - tmp1;
      *y = 4095 - tmp2;
  }
  end_touch_read_write();
  return true;
}
touch.h
public:
void set_touch_rotation(uint8_t rotation);
private:
uint8_t _rotation = 0;      