### PR TITLE
Compiler error since latest Feature update

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -57,7 +57,7 @@ inline void TFT_eSPI::begin_tft_write(void){
     locked = false;
     spi.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, TFT_SPI_MODE));
     CS_L;
-    SET_BUS_WRITE_MODE
+    SET_BUS_WRITE_MODE;
   }
 #else
   CS_L;


### PR DESCRIPTION
## Configuration

ESP8266 with ILI9341:

```
Processing d1-mini-esp8266_ili9341 (platform: espressif8266@^2.6.2; board: d1_mini; framework: arduino)
-------------------------------------------------------------------------------------------------------
CONFIGURATION: https://docs.platformio.org/page/boards/espressif8266/d1_mini.html
PLATFORM: Espressif 8266 (2.6.2) > WeMos D1 R2 and mini
HARDWARE: ESP8266 160MHz, 80KB RAM, 4MB Flash
PACKAGES:
 - framework-arduinoespressif8266 3.20704.0 (2.7.4)
 - tool-esptool 1.413.0 (4.13) 
 - tool-esptoolpy 1.20800.0 (2.8.0)
 - toolchain-xtensa 2.40802.200502 (4.8.2)

build_flags =
    -D ILI9341_DRIVER=1
    -D TFT_WIDTH=240
    -D TFT_HEIGHT=320
    -D TFT_ROTATION=0
    -D SPI_FREQUENCY=40000000
    -D SPI_TOUCH_FREQUENCY=2500000
    -D SPI_READ_FREQUENCY=20000000
    -D USER_SETUP_LOADED=1
    -D SUPPORT_TRANSACTIONS
    ;-D TFT_MISO=12 ;D6  Use default HSPI
    ;-D TFT_MOSI=13 ;D7  Use default HSPI
    ;-D TFT_SCLK=14 ;D5  Use default HSPI
    -D TFT_DC=15    ;D8
    -D TFT_CS=16    ;D0
    -D TFT_BCKL=-1  ;None
    -D TOUCH_CS=0   ;D3  (can also be D1 or D2)
    -D TFT_RST=-1   ;RST
```

## Problem

Compiler error since latest Feature update commit 42e6fc8:

```
lib\d1-mini-esp8266_ili9341\TFT_eSPI@src-de9489f509\TFT_eSPI.cpp: In member function 'void TFT_eSPI::begin_tft_write()':
lib\d1-mini-esp8266_ili9341\TFT_eSPI@src-de9489f509\TFT_eSPI.cpp:61:3: error: expected ';' before '}' token
   }
   ^
```

## Solution

Previous commit 3b39bf1 compiles fine. The issue is with commit 42e6fc8.
When I add a `;` to line TFT_eSPI.cpp:61:3 the library compiles again without error.

## 
