### PR TITLE
add GC9A01 option

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -2990,7 +2990,7 @@ void TFT_eSPI::drawPixel(int32_t x, int32_t y, uint32_t color)
   if ((rotation & 0x1) == 0) { swap_coord(x, y); }
 #endif
 
-#ifdef MULTI_TFT_SUPPORT
+#if defined (MULTI_TFT_SUPPORT) || defined (GC9A01_DRIVER)
   // No optimisation
   DC_C; tft_Write_8(TFT_CASET);
   DC_D; tft_Write_32D(x);
@@ -2998,21 +2998,21 @@ void TFT_eSPI::drawPixel(int32_t x, int32_t y, uint32_t color)
   DC_D; tft_Write_32D(y);
 #else
   // No need to send x if it has not changed (speeds things up)
-  if (addr_col != (x<<16 | x)) {
+  if (addr_col != x) {
     DC_C; tft_Write_8(TFT_CASET);
     DC_D; tft_Write_32D(x);
-    addr_col = (x<<16 | x);
+    addr_col = x;
   }
 
   // No need to send y if it has not changed (speeds things up)
-  if (addr_row != (y<<16 | y)) {
+  if (addr_row != y) {
     DC_C; tft_Write_8(TFT_PASET);
     DC_D; tft_Write_32D(y);
-    addr_row = (y<<16 | y);
+    addr_row = y;
   }
 #endif
   DC_C; tft_Write_8(TFT_RAMWR);
-  DC_D; tft_Write_16(color);
+    DC_D; tft_Write_16(color);
 #endif
 
   end_tft_write();

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -54,7 +54,7 @@
 //#define SSD1963_800_DRIVER
 //#define SSD1963_800ALT_DRIVER
 //#define ILI9225_DRIVER
-#define GC9A01_DRIVER
+//#define GC9A01_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -54,12 +54,13 @@
 //#define SSD1963_800_DRIVER
 //#define SSD1963_800ALT_DRIVER
 //#define ILI9225_DRIVER
+#define GC9A01_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.
 // To use the SDA line for reading data from the TFT uncomment the following line:
 
-// #define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 display only
+// #define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 and GC9A01 display only
 
 // For ST7735, ST7789 and ILI9341 ONLY, define the colour order IF the blue and red are swapped on your display
 // Try ONE option at a time to find the correct colour order for your display
@@ -71,7 +72,7 @@
 
 // #define M5STACK
 
-// For ST7789, ST7735 and ILI9163 ONLY, define the pixel width and height in portrait orientation
+// For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
 // #define TFT_WIDTH  80
 // #define TFT_WIDTH  128
 // #define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
@@ -79,6 +80,7 @@
 // #define TFT_HEIGHT 128
 // #define TFT_HEIGHT 240 // ST7789 240 x 240
 // #define TFT_HEIGHT 320 // ST7789 240 x 320
+#define TFT_HEIGHT 240 // GC9A01 240 x 240
 
 // For ST7735 ONLY, define the type of display, originally this was based on the
 // colour of the tab on the screen protector film but this is not always true, so try
@@ -196,6 +198,16 @@
 //#define TFT_DC    2  // Data Command control pin
 //#define TFT_RST   4  // Reset pin (could connect to RST pin)
 //#define TFT_RST  -1  // Set TFT_RST to -1 if display RESET is connected to ESP32 board RST
+
+// For ESP32 Dev board (only tested with GC9A01 display)
+// The hardware SPI can be mapped to any pins
+
+//#define TFT_MOSI 15 // In some display driver board, it might be written as "SDA" and so on.
+//#define TFT_SCLK 14
+//#define TFT_CS   5  // Chip select control pin
+//#define TFT_DC   27  // Data Command control pin
+//#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
+//#define TFT_BL   22  // LED back-light
 
 //#define TOUCH_CS 21     // Chip select pin (T_CS) of touch screen
 

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -78,6 +78,8 @@
 
 //#include <User_Setups/Setup135_ST7789.h>           // Setup file for ESP8266 and ST7789 135 x 240 TFT
 
+//#include <User_Setups/Setup200_GC9A01.h>           // Setup file for ESP32 and GC9A01 240 x 240 TFT
+
 //#include <User_Setups/SetupX_Template.h>
 
 

--- a/User_Setups/Setup200_GC9A01.h
+++ b/User_Setups/Setup200_GC9A01.h
@@ -1,0 +1,31 @@
+// See SetupX_Template.h for all options available
+
+#define GC9A01_DRIVER
+
+// For ESP32 Dev board (only tested with GC9A01 display)
+// The hardware SPI can be mapped to any pins
+
+#define TFT_MOSI 15 // In some display driver board, it might be written as "SDA" and so on.
+#define TFT_SCLK 14
+#define TFT_CS   5  // Chip select control pin
+#define TFT_DC   27  // Data Command control pin
+#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
+#define TFT_BL   22  // LED back-light
+
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+
+//#define SPI_FREQUENCY  80000000
+#define SPI_FREQUENCY  27000000
+
+// Optional reduced SPI frequency for reading TFT
+#define SPI_READ_FREQUENCY  5000000

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -50,6 +50,7 @@
 //#define R61581_DRIVER
 //#define RM68140_DRIVER
 //#define ST7796_DRIVER
+//#define GC9A01_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.


### PR DESCRIPTION
I added the option GC9A01 (240*240) TFT display and tested on ESP32 Dev Module.

Most of the example sketch in 'TFT_eSPI/examples/320 x 240' can work.