### PR TITLE
Update ST7789_Init.h

### DIFF
--- a/TFT_Drivers/ST7789_Init.h
+++ b/TFT_Drivers/ST7789_Init.h
@@ -25,6 +25,9 @@
   writedata(0x55);
   delay(10);
 
+  writecommand(ST7789_RAMCTRL);
+  writedata(0x00);
+  writedata(0xC0);
   //--------------------------------ST7789V Frame rate setting----------------------------------//
   writecommand(ST7789_PORCTRL);
   writedata(0x0c);


### PR DESCRIPTION
added ST7789_RAMCTRL setting
otherwise the default value of the second parameter, 0xF0, causes LSB of green being copied to LSB of red and blue in 16 Bit color mode, making every uneven green value grayish