### PR TITLE
Dangerous edge case for non-null-terminated string

### DIFF
--- a/Extensions/Button.cpp
+++ b/Extensions/Button.cpp
@@ -36,6 +36,7 @@ void TFT_eSPI_Button::initButtonUL(
   _textsize     = textsize;
   _gfx          = gfx;
   strncpy(_label, label, 9);
+  _label[9] = 0;  // strncpy does not place a null at the end. When 'label' is 9 characters, _label is not terminated.
 }
 
 // Adjust text datum and x, y deltas


### PR DESCRIPTION
strncpy() does not place a null terminator when the max characters is reached of '9' in this case. So, any buttons with 9 or more in the source will wind up with a potentially non-null-terminated _label.