### PR TITLE
FAST_UNICODE_INDEX - faster binary search for index from unicode code point

### DIFF
--- a/Extensions/Smooth_font.cpp
+++ b/Extensions/Smooth_font.cpp
@@ -338,6 +338,37 @@ uint32_t TFT_eSPI::readInt32(void)
 ** Function name:           getUnicodeIndex
 ** Description:             Get the font file index of a Unicode character
 *************************************************************************************x*/
+
+#ifdef FAST_UNICODE_INDEX
+bool TFT_eSPI::getUnicodeIndex(uint16_t unicode, uint16_t *index)
+{
+  int above = gFont.gCount;
+  int bottom = 0;
+  int i = above / 2;
+  do
+  {
+    uint16_t code = gUnicode[i];
+    if (code == unicode)
+    {
+      *index = i;
+      return true;
+    }
+    if (code > unicode)
+    {
+      above = i;
+    }
+    else
+    {
+      bottom = i+1;
+    }
+    i = (above+bottom)/2;
+  } while (above > bottom);
+
+  return false;
+}
+
+#else
+
 bool TFT_eSPI::getUnicodeIndex(uint16_t unicode, uint16_t *index)
 {
   for (uint16_t i = 0; i < gFont.gCount; i++)
@@ -350,6 +381,8 @@ bool TFT_eSPI::getUnicodeIndex(uint16_t unicode, uint16_t *index)
   }
   return false;
 }
+
+#endif
 
 
 /***************************************************************************************

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -304,6 +304,8 @@
 // this will save ~20kbytes of FLASH
 #define SMOOTH_FONT
 
+// Smooth font improvements
+#define FAST_UNICODE_INDEX
 
 // ##################################################################################
 //


### PR DESCRIPTION
Hello, Bodmer!
I am using this great lib for making my mp3 player.
The font I need for display must contain wide unicode range: cyrillic, japanese, math symbols, etc, all that can be found in mp3 tags. The number of glyphs in the font is about 13800.
I have noticed that when I print glyphs with high codes, the speed is much slower, compared to base ascii range chars. 
The function that searches index from code point is simply looks for the given code iterating all glyphs of the font in the worst case.
The function that I offer here is binary search, which execution time is O(log(N)), is much faster in average than original, which execution time is O(N), where N = gFont.gCount.
I am using ESP32 + ST7789 (TTGO-TM) with 16MB of flash. For tests I use four printing methods from examples Font_Demo_x_Array. By my measurements the speed improvement is from 1...7% (on basic 95 glyphs font) to 110% (on 13K glyphs font). This result means that original function index searching time in my case (13K glyphs) is comparable to printing time itself.
The function only works with the fonts ordered by unicode code point, and that's why there is #define in User_Setup.h: for that strange cases when font is not ordered.
