### PR TITLE
Fix HX8375D rotation values

### DIFF
--- a/TFT_Drivers/HX8357D_Rotation.h
+++ b/TFT_Drivers/HX8357D_Rotation.h
@@ -1,26 +1,47 @@
-  // This is the command sequence that rotates the ILI9481 driver coordinate frame
+  // This is the command sequence that rotates the HX8357D driver coordinate frame
 
-  writecommand(TFT_MADCTL);
-  rotation = m % 4;
-  switch (rotation) {
-   case 0: // Portrait
-     writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-     break;
-   case 1: // Landscape (Portrait + 90)
-     writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
-     break;
-   case 2: // Inverter portrait
-     writedata(TFT_MAD_RGB);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-     break;
-   case 3: // Inverted landscape
-     writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
-     break;
-  }
+writecommand(TFT_MADCTL);
+rotation = m % 8;
+switch (rotation)
+{
+case 0: // Portrait
+  writedata(TFT_MAD_BGR | TFT_MAD_MX);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 1: // Landscape (Portrait + 90)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 2: // Inverter portrait
+  writedata(TFT_MAD_BGR | TFT_MAD_MY);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 3: // Inverted landscape
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_MY);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 4: // Portrait
+  writedata(TFT_MAD_BGR | TFT_MAD_MX | TFT_MAD_MY);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 5: // Landscape (Portrait + 90)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 6: // Inverter portrait
+  writedata(TFT_MAD_BGR);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 7: // Inverted landscape
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MY);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+}


### PR DESCRIPTION
This is for the Adafruit HX8357D driver
![hx8357d](https://user-images.githubusercontent.com/12903207/136386625-135cc02d-8c47-4947-930d-ab03b7a71a69.jpg)


For the HX8357D, the current bits that are written to the MADCTL control register cause all of the text to be mirrored. This affects every rotation value.

tft.setRotation(0)

![original_0](https://user-images.githubusercontent.com/12903207/136386192-3af7e4f2-7bef-4f00-93b2-03014f6208ae.jpg)

tft.setRotation(1)

![original_1](https://user-images.githubusercontent.com/12903207/136386238-3abdd37b-d766-4ed9-9050-443c28ab8e1d.jpg)

tft.setRotation(2)

![original_2](https://user-images.githubusercontent.com/12903207/136386288-fa0a6476-ec0c-46d9-a08f-4e63183f3f4c.jpg)

tft.setRotation(3)

![original_3](https://user-images.githubusercontent.com/12903207/136387861-111df30f-f420-465a-9a02-5e8e985ba008.jpg)

If we use the same command values from the ILI9486 rotation, then rotated text displays like normal.

tft.setRotation(0)
![fix_0](https://user-images.githubusercontent.com/12903207/136386337-d1804038-1d72-4368-af14-fdee33d45af0.jpg)

tft.setRotation(1)
![fix_1](https://user-images.githubusercontent.com/12903207/136386375-810f50e3-7ecf-4a9b-abd6-c1d3f2e158b8.jpg)

tft.setRotation(2)
![fix_2](https://user-images.githubusercontent.com/12903207/136386421-81e5c63e-adac-4dc4-9720-e69bf57a83e2.jpg)

tft.setRotation(3)
![fix_3](https://user-images.githubusercontent.com/12903207/136386459-c4f7f4e7-52a2-4f0d-829a-aab26f9fa552.jpg)


tft.setRotation(3)

