### PR TITLE
Support Software SPI processor

### DIFF
--- a/Processors/TFT_eSPI_SWSPI.c
+++ b/Processors/TFT_eSPI_SWSPI.c
@@ -1,0 +1,37 @@
+        ////////////////////////////////////////////////////
+        //       TFT_eSPI Software SPI driver functions        //
+        ////////////////////////////////////////////////////
+
+/***************************************************************************************
+** Function name:           tft_Write8_8
+** Description:             basic softare SPI write function
+***************************************************************************************/
+void tft_Write_8(uint8_t c)
+{
+  for(uint8_t bit = 0x80; bit; bit >>= 1) {
+    if(c & bit) digitalWrite(TFT_MOSI, HIGH);
+    else        digitalWrite(TFT_MOSI, LOW);
+    digitalWrite(TFT_SCLK, HIGH);
+    digitalWrite(TFT_SCLK, LOW);
+  }
+}
+
+/***************************************************************************************
+** Function name:           pushPixels - for software SPI
+** Description:             Write a sequence of pixels
+***************************************************************************************/
+void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
+
+  uint16_t *data = (uint16_t*)data_in;
+
+  if (_swapBytes) while ( len-- ) {tft_Write_16(*data); data++;}
+  else while ( len-- ) {tft_Write_16S(*data); data++;}
+}
+
+/***************************************************************************************
+** Function name:           pushBlock  - for software SPI
+** Description:             Write a block of pixels of the same colour
+***************************************************************************************/
+void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
+  while (len--) {tft_Write_16(color);}
+}

--- a/Processors/TFT_eSPI_SWSPI.h
+++ b/Processors/TFT_eSPI_SWSPI.h
@@ -1,0 +1,62 @@
+        ////////////////////////////////////////////////////
+        //       TFT_eSPI Sotware SPI driver functions        //
+        ////////////////////////////////////////////////////
+
+// This is a software api driver for Arduino boards, it supports SPI interface displays
+
+#ifndef _TFT_eSPI_SWSPI_
+#define _TFT_eSPI_SWSPI_
+
+// Initialise processor specific SPI functions, used by init()
+#define INIT_TFT_DATA_BUS // Not used
+
+// Processor specific code used by SPI bus transaction startWrite and endWrite functions
+#define SET_BUS_WRITE_MODE // Not used
+#define SET_BUS_READ_MODE  // Not used
+
+// Code to check if DMA is busy, used by SPI bus transaction startWrite and endWrite functions
+#define DMA_BUSY_CHECK // Not used so leave blank
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the DC (TFT Data/Command or Register Select (RS))pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_DC
+  #define DC_C // No macro allocated so it generates no code
+  #define DC_D // No macro allocated so it generates no code
+#else
+  #define DC_C digitalWrite(TFT_DC, LOW)
+  #define DC_D digitalWrite(TFT_DC, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Define the CS (TFT chip select) pin drive code
+////////////////////////////////////////////////////////////////////////////////////////
+#ifndef TFT_CS
+  #define CS_L // No macro allocated so it generates no code
+  #define CS_H // No macro allocated so it generates no code
+#else
+  #define CS_L digitalWrite(TFT_CS, LOW)
+  #define CS_H digitalWrite(TFT_CS, HIGH)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Macros to write commands/pixel colour data to a SPI
+////////////////////////////////////////////////////////////////////////////////////////
+
+  // Write 16 bits to TFT
+  #define tft_Write_16(C)  tft_Write_8(C>>8); tft_Write_8(C)
+
+  // Write Swapped 16 bits to TFT
+  #define tft_Write_16S(C) uint16_t Cswap = ((C) >>8 | (C) << 8); \
+                           tft_Write_16(Cswap)
+
+  // Future option for transfer without wait
+  #define tft_Write_16N(C) tft_Write_16(C)
+
+    // Write two concatenated 16 bit values to TFT
+  #define tft_Write_32C(C,D) 	tft_Write_16(C); tft_Write_16(D);
+
+  // Write same value twice
+  #define tft_Write_32D(C) tft_Write_16((uint16_t) (C)); tft_Write_16((uint16_t) (C))
+
+#endif // Header end

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -61,7 +61,9 @@
 #endif
 
 // Include the processor specific drivers
-#if defined (ESP32)
+#if defined (TFT_eSPI_USE_SWSPI)
+  #include "Processors/TFT_eSPI_SWSPI.h"
+#elif defined (ESP32)
   #include "Processors/TFT_eSPI_ESP32.h"
 #elif defined (ESP8266)
   #include "Processors/TFT_eSPI_ESP8266.h"


### PR DESCRIPTION
* some project can't use MCU SPI inteface because
  it will break other real-time interrupt service

  so that user software spi instead of spi bus