### PR TITLE
Allow changing the display size via TFT_eSPI constructor

### DIFF
--- a/TFT_Drivers/HX8357D_Rotation.h
+++ b/TFT_Drivers/HX8357D_Rotation.h
@@ -5,22 +5,22 @@
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
    case 2: // Inverter portrait
      writedata(TFT_MAD_RGB);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
   }

--- a/TFT_Drivers/ILI9481_Rotation.h
+++ b/TFT_Drivers/ILI9481_Rotation.h
@@ -5,23 +5,23 @@
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_BGR | TFT_MAD_SS);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
    case 2: // Inverter portrait
      writedata(TFT_MAD_BGR | TFT_MAD_GS);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MV | TFT_MAD_BGR | TFT_MAD_SS | TFT_MAD_GS);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
   }
    

--- a/TFT_Drivers/ILI9488_Rotation.h
+++ b/TFT_Drivers/ILI9488_Rotation.h
@@ -5,23 +5,23 @@
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_MX | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
    case 2: // Inverter portrait
      writedata(TFT_MAD_MY | TFT_MAD_BGR);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
   }
    

--- a/TFT_Drivers/R61581_Rotation.h
+++ b/TFT_Drivers/R61581_Rotation.h
@@ -5,23 +5,23 @@
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_BGR | TFT_MAD_MX);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_MV | TFT_MAD_BGR);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
    case 2: // Inverter portrait
      writedata(TFT_MAD_BGR | TFT_MAD_GS);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MV | TFT_MAD_BGR | TFT_MAD_MX | TFT_MAD_GS);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
   }
    

--- a/TFT_Drivers/RM68140_Rotation.h
+++ b/TFT_Drivers/RM68140_Rotation.h
@@ -10,8 +10,8 @@
      writedata(0);
      writedata(0x22);
      writedata(0x3B);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 1: // Landscape (Portrait + 90)
      writedata(TFT_MAD_MV | TFT_MAD_BGR);
@@ -19,8 +19,8 @@
      writedata(0);
      writedata(0x02);
      writedata(0x3B);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
    case 2: // Inverter portrait
      writedata(TFT_MAD_BGR);
@@ -28,8 +28,8 @@
      writedata(0);
      writedata(0x42);
      writedata(0x3B);
-      _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
+      _width  = _init_width;
+      _height = _init_height;
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MV | TFT_MAD_BGR);
@@ -37,8 +37,8 @@
      writedata(0);
      writedata(0x62);
      writedata(0x3B);
-      _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
+      _width  = _init_height;
+      _height = _init_width;
      break;
   }
    


### PR DESCRIPTION
Hello,
This patch allows to change the display size via `TFT_eSPI display(w, h);` for the LCD drivers HX8357D, ILI9481, ILI9488, R61581, RM68140. I used it to “simulate” a smaller sized display (with ILI9488). I don’t know if the usage of the variables `TFT_*` instead of `_init_*` was intentional or a mistake, but I hope the change of these allows for more flexibility.
![signal-2021-11-21-184115](https://user-images.githubusercontent.com/22944000/142773169-92b9ee17-d1e2-459c-b193-7951bd4f294f.jpeg)