### PR TITLE
[wip] add esp32-c3 support

### DIFF
--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -213,7 +213,6 @@ void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
 ***************************************************************************************/
 /*
 void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
-  
   uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);
   bool empty = true;
   volatile uint32_t* spi_w = (volatile uint32_t*)_spi_w;
@@ -262,7 +261,7 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
 void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
 
   volatile uint32_t* spi_w = _spi_w;
-  uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);  
+  uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);
   uint32_t i = 0;
   uint32_t rem = len & 0x1F;
   len =  len - rem;
@@ -287,7 +286,7 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
   {
     while (*_spi_cmd&SPI_USR);
     *_spi_cmd = SPI_USR;
-      len -= 32;
+    len -= 32;
   }
 
   // Do not wait here
@@ -315,7 +314,7 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
         data+=4;
       }
       while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
-      WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]); 
+      WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]);
       WRITE_PERI_REG(SPI_W1_REG(SPI_PORT),  color[1]);
       WRITE_PERI_REG(SPI_W2_REG(SPI_PORT),  color[2]);
       WRITE_PERI_REG(SPI_W3_REG(SPI_PORT),  color[3]);
@@ -346,7 +345,7 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
     }
     while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
     WRITE_PERI_REG(SPI_MOSI_DLEN_REG(SPI_PORT), 255);
-    WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]); 
+    WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]);
     WRITE_PERI_REG(SPI_W1_REG(SPI_PORT),  color[1]);
     WRITE_PERI_REG(SPI_W2_REG(SPI_PORT),  color[2]);
     WRITE_PERI_REG(SPI_W3_REG(SPI_PORT),  color[3]);
@@ -832,5 +831,5 @@ void TFT_eSPI::deInitDMA(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-#endif // End of DMA FUNCTIONS    
+#endif // End of DMA FUNCTIONS
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -213,7 +213,7 @@ void TFT_eSPI::pushPixels(const void* data_in, uint32_t len)
 ***************************************************************************************/
 /*
 void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
-
+  
   uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);
   bool empty = true;
   volatile uint32_t* spi_w = (volatile uint32_t*)_spi_w;
@@ -262,7 +262,7 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
 void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
 
   volatile uint32_t* spi_w = _spi_w;
-  uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);
+  uint32_t color32 = (color<<8 | color >>8)<<16 | (color<<8 | color >>8);  
   uint32_t i = 0;
   uint32_t rem = len & 0x1F;
   len =  len - rem;
@@ -287,7 +287,7 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
   {
     while (*_spi_cmd&SPI_USR);
     *_spi_cmd = SPI_USR;
-    len -= 32;
+      len -= 32;
   }
 
   // Do not wait here
@@ -315,7 +315,7 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
         data+=4;
       }
       while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
-      WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]);
+      WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]); 
       WRITE_PERI_REG(SPI_W1_REG(SPI_PORT),  color[1]);
       WRITE_PERI_REG(SPI_W2_REG(SPI_PORT),  color[2]);
       WRITE_PERI_REG(SPI_W3_REG(SPI_PORT),  color[3]);
@@ -346,7 +346,7 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
     }
     while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
     WRITE_PERI_REG(SPI_MOSI_DLEN_REG(SPI_PORT), 255);
-    WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]);
+    WRITE_PERI_REG(SPI_W0_REG(SPI_PORT),  color[0]); 
     WRITE_PERI_REG(SPI_W1_REG(SPI_PORT),  color[1]);
     WRITE_PERI_REG(SPI_W2_REG(SPI_PORT),  color[2]);
     WRITE_PERI_REG(SPI_W3_REG(SPI_PORT),  color[3]);
@@ -832,5 +832,5 @@ void TFT_eSPI::deInitDMA(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-#endif // End of DMA FUNCTIONS
+#endif // End of DMA FUNCTIONS    
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -73,10 +73,10 @@ SPI3_HOST = 2
   #endif
 
   #ifdef CONFIG_IDF_TARGET_ESP32C3
-    #define SPI_PORT 2    //FSPI(ESP32 C3)
-  #else
-    #define SPI_PORT 2 //FSPI(ESP32 S2)
-  #endif
+      #define SPI_PORT 2    //FSPI(ESP32 C3)
+    #else
+      #define SPI_PORT 2 //FSPI(ESP32 S2)
+    #endif
 #endif
 
 #ifdef RPI_DISPLAY_TYPE
@@ -527,10 +527,19 @@ SPI3_HOST = 2
   #define tft_Write_32D(C) TFT_WRITE_BITS((uint16_t)((C)<<8 | (C)>>8)<<16 | (uint16_t)((C)<<8 | (C)>>8), 32)
 //*/
 //* Replacement slimmer macros
-  #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;    \
-                               *_spi_w = D;             \
-                               *_spi_cmd = SPI_USR;      \
-                        while (*_spi_cmd & SPI_USR);
+  #if CONFIG_IDF_TARGET_ESP32C3 
+    #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;    \
+                                *_spi_w = D;             \
+                                *_spi_cmd = SPI_UPDATE; \
+                          while (*_spi_cmd & SPI_UPDATE); \
+                                *_spi_cmd = SPI_USR;      \
+                          while (*_spi_cmd & SPI_USR);
+  #else 
+    #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;    \
+                                *_spi_w = D;             \
+                                *_spi_cmd = SPI_USR;      \
+                          while (*_spi_cmd & SPI_USR);
+  #endif
 
   // Write 8 bits
   #define tft_Write_8(C) TFT_WRITE_BITS(C, 8)

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -46,8 +46,8 @@ HSPI = 2, uses SPI3
 VSPI not defined
 
 ESP32 C3:
-FSPI = 0, uses SPI2 ???? To be checked
-HSPI = 1, uses SPI3 ???? To be checked
+FSPI = 0, uses SPI2
+HSPI = 1, uses SPI2
 VSPI not defined
 
 For ESP32/S2/C3:
@@ -61,13 +61,21 @@ SPI3_HOST = 2
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT HSPI  //HSPI is port 2 on ESP32
   #else
-    #define SPI_PORT 3     //HSPI is port 3 on ESP32 S2
+    #ifdef CONFIG_IDF_TARGET_ESP32C3
+      #define SPI_PORT 2    //HSPI is port 1 on the ESP32 c3
+    #else
+      #define SPI_PORT 3     //HSPI is port 3 on ESP32 S2
+    #endif
   #endif
 #else
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT VSPI
   #else
-    #define SPI_PORT 2 //FSPI(ESP32 S2)
+    #ifdef CONFIG_IDF_TARGET_ESP32C3
+      #define SPI_PORT 2    //FSPI(ESP32 C3)
+    #else
+      #define SPI_PORT 2 //FSPI(ESP32 S2)
+    #endif
   #endif
 #endif
 
@@ -322,7 +330,7 @@ SPI3_HOST = 2
 
   // Create a bit set lookup table for data bus - wastes 1kbyte of RAM but speeds things up dramatically
   // can then use e.g. GPIO.out_w1ts = set_mask(0xFF); to set data bus to 0xFF
-  #define PARALLEL_INIT_TFT_DATA_BUS               \
+  #define CONSTRUCTOR_INIT_TFT_DATA_BUS            \
   for (int32_t c = 0; c<256; c++)                  \
   {                                                \
     xset_mask[c] = 0;                              \

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -60,22 +60,22 @@ SPI3_HOST = 2
 #ifdef USE_HSPI_PORT
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT HSPI  //HSPI is port 2 on ESP32
-  #else
-    #ifdef CONFIG_IDF_TARGET_ESP32C3
+  #endif
+
+  #ifdef CONFIG_IDF_TARGET_ESP32C3
       #define SPI_PORT 2    //HSPI is port 1 on the ESP32 c3
     #else
       #define SPI_PORT 3     //HSPI is port 3 on ESP32 S2
     #endif
-  #endif
 #else
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT VSPI
+  #endif
+
+  #ifdef CONFIG_IDF_TARGET_ESP32C3
+    #define SPI_PORT 2    //FSPI(ESP32 C3)
   #else
-    #ifdef CONFIG_IDF_TARGET_ESP32C3
-      #define SPI_PORT 2    //FSPI(ESP32 C3)
-    #else
-      #define SPI_PORT 2 //FSPI(ESP32 S2)
-    #endif
+    #define SPI_PORT 2 //FSPI(ESP32 S2)
   #endif
 #endif
 

--- a/User_Setups/Setup72_ESP32_C3_ILI9341.h
+++ b/User_Setups/Setup72_ESP32_C3_ILI9341.h
@@ -5,11 +5,11 @@
 #define USE_HSPI_PORT
 
 #define TFT_MOSI 7
-#define TFT_MISO 5
+#define TFT_MISO 2
 #define TFT_SCLK 6
-#define TFT_CS   9 // Chip select control pin
-#define TFT_DC   19  // Data Command control pin
-#define TFT_RST  18  // Reset pin (could connect to RST pin)
+#define TFT_CS   10 // Chip select control pin
+#define TFT_DC   9  // Data Command control pin
+#define TFT_RST  4  // Reset pin (could connect to RST pin)
 
 // Optional - define for XPT2046 touch controller
 #define TOUCH_CS 8     // Chip select pin (T_CS) of touch screen

--- a/User_Setups/Setup72_ESP32_C3_ILI9341.h
+++ b/User_Setups/Setup72_ESP32_C3_ILI9341.h
@@ -1,0 +1,31 @@
+#define TFT_WIDTH  320
+#define TFT_HEIGHT 240
+
+#define ILI9341_DRIVER
+#define USE_HSPI_PORT
+
+#define TFT_MOSI 7
+#define TFT_MISO 5
+#define TFT_SCLK 6
+#define TFT_CS   9 // Chip select control pin
+#define TFT_DC   19  // Data Command control pin
+#define TFT_RST  18  // Reset pin (could connect to RST pin)
+
+// Optional - define for XPT2046 touch controller
+#define TOUCH_CS 8     // Chip select pin (T_CS) of touch screen
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+// Comment out the #define below to stop the SPIFFS filing system and smooth font code being loaded
+// this will save ~20kbytes of FLASH
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY  27000000
+
+#define SPI_READ_FREQUENCY  6000000 // 6 MHz is the maximum SPI read speed for the ST7789V


### PR DESCRIPTION
This is a work in progress to get c3 support added.

I am using https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/spi_master.html#_CPPv429spi_device_interface_config_t as a point of reference to the SPI configuration. 

One of the biggest differences between the s2 and the c3 is the SPI peripherals 

| s2 | c3 |
|---|----|
| <img width="762" alt="Screen Shot 2022-01-27 at 6 40 46 PM" src="https://user-images.githubusercontent.com/1854811/151477953-5a92b7b0-e1ce-4193-8340-7772f6fa33f1.png"> | <img width="766" alt="Screen Shot 2022-01-27 at 6 40 53 PM" src="https://user-images.githubusercontent.com/1854811/151477964-0300b000-acb0-4e03-a222-33ff32e84ae2.png"> |
 
I am using https://github.com/espressif/esp-idf/blob/d587a1ce6d53c505d970cc951d357d4f95eeedc8/examples/peripherals/spi_master/lcd/main/spi_master_example_main.c as a place to reference settings. 