### PR TITLE
added USE_FSPI_PORT flag to support more ESP32-S2 boards

### DIFF
--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -11,16 +11,18 @@
   #ifdef CONFIG_IDF_TARGET_ESP32
     #ifdef USE_HSPI_PORT
       SPIClass spi = SPIClass(HSPI);
+    #elif defined(USE_FSPI_PORT)
+      SPIClass spi = SPIClass(FSPI);
     #else // use default VSPI port
-      //SPIClass& spi = SPI;
       SPIClass spi = SPIClass(VSPI);
     #endif
   #else
     #ifdef USE_HSPI_PORT
       SPIClass spi = SPIClass(HSPI);
-    #else // use FSPI port
-      //SPIClass& spi = SPI;
+    #elif defined(USE_FSPI_PORT)
       SPIClass spi = SPIClass(FSPI);
+    #else // use FSPI port
+      SPIClass& spi = SPI;
     #endif
   #endif
 #endif
@@ -32,6 +34,8 @@
     #define DMA_CHANNEL 1
     #ifdef USE_HSPI_PORT
       spi_host_device_t spi_host = HSPI_HOST;
+    #elif defined(USE_FSPI_PORT)
+      spi_host_device_t spi_host = SPI_HOST;
     #else // use VSPI port
       spi_host_device_t spi_host = VSPI_HOST;
     #endif

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -67,6 +67,8 @@ SPI3_HOST = 2
   #else
     #define SPI_PORT 3     //HSPI is port 3 on ESP32 S2
   #endif
+#elif defined(USE_FSPI_PORT)
+    #define SPI_PORT 2 //FSPI(ESP32 S2)
 #else
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT VSPI


### PR DESCRIPTION
Hi,
I have added a new flag USE_FSPI_PORT to explicitely set the FSPI port and support more ESP32-S2 boards.
This change allowed me to use this library on an Adafruit QtPy ESP32-S2 which won't work otherwise.

Thank You for that great library!