### PR TITLE
Error compiling for board Nucleo-144

### DIFF
--- a/TFT_Drivers/NT35510_Defines.h
+++ b/TFT_Drivers/NT35510_Defines.h
@@ -1,0 +1,81 @@
+// Change the width and height if required (defined in portrait mode)
+// or use the constructor to over-ride defaults
+#define TFT_WIDTH  800
+#define TFT_HEIGHT 480
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+
+#define TFT_RAMRD   0x2E
+
+#define TFT_MADCTL  0x36
+
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+//#define TFT_MAD_MH  0x04
+//#define TFT_MAD_SS  0x02
+//#define TFT_MAD_GS  0x01
+
+/* Manufacturer Command Set */
+#define MCS_ADRSFT	0x0000	/* Address Shift Function */
+#define MCS_PANSET	0xB3A6	/* Panel Type Setting */
+#define MCS_SD_CTRL	0xC0A2	/* Source Driver Timing Setting */
+#define MCS_P_DRV_M	0xC0B4	/* Panel Driving Mode */
+#define MCS_OSC_ADJ	0xC181	/* Oscillator Adjustment for Idle/Normal mode */
+#define MCS_RGB_VID_SET	0xC1A1	/* RGB Video Mode Setting */
+#define MCS_SD_PCH_CTRL	0xC480	/* Source Driver Precharge Control */
+#define MCS_NO_DOC1	0xC48A	/* Command not documented */
+#define MCS_PWR_CTRL1	0xC580	/* Power Control Setting 1 */
+#define MCS_PWR_CTRL2	0xC590	/* Power Control Setting 2 for Normal Mode */
+#define MCS_PWR_CTRL4	0xC5B0	/* Power Control Setting 4 for DC Voltage */
+#define MCS_PANCTRLSET1	0xCB80	/* Panel Control Setting 1 */
+#define MCS_PANCTRLSET2	0xCB90	/* Panel Control Setting 2 */
+#define MCS_PANCTRLSET3	0xCBA0	/* Panel Control Setting 3 */
+#define MCS_PANCTRLSET4	0xCBB0	/* Panel Control Setting 4 */
+#define MCS_PANCTRLSET5	0xCBC0	/* Panel Control Setting 5 */
+#define MCS_PANCTRLSET6	0xCBD0	/* Panel Control Setting 6 */
+#define MCS_PANCTRLSET7	0xCBE0	/* Panel Control Setting 7 */
+#define MCS_PANCTRLSET8	0xCBF0	/* Panel Control Setting 8 */
+#define MCS_PANU2D1	0xCC80	/* Panel U2D Setting 1 */
+#define MCS_PANU2D2	0xCC90	/* Panel U2D Setting 2 */
+#define MCS_PANU2D3	0xCCA0	/* Panel U2D Setting 3 */
+#define MCS_PAND2U1	0xCCB0	/* Panel D2U Setting 1 */
+#define MCS_PAND2U2	0xCCC0	/* Panel D2U Setting 2 */
+#define MCS_PAND2U3	0xCCD0	/* Panel D2U Setting 3 */
+#define MCS_GOAVST	0xCE80	/* GOA VST Setting */
+#define MCS_GOACLKA1	0xCEA0	/* GOA CLKA1 Setting */
+#define MCS_GOACLKA2	0xCEA7	/* GOA CLKA2 Setting */
+#define MCS_GOACLKA3	0xCEB0	/* GOA CLKA3 Setting */
+#define MCS_GOACLKA4	0xCEB7	/* GOA CLKA4 Setting */
+#define MCS_GOAECLK		0xCFC0	/* GOA ECLK Setting */
+#define MCS_GOAOPT1		0xCFC6	/* GOA Other Options 1 */
+#define MCS_GOATGOPT	0xCFC7	/* GOA Signal Toggle Option Setting */
+#define MCS_NO_DOC2	0xCFD0	/* Command not documented */
+#define MCS_GVDDSET	0xD800	/* GVDD/NGVDD */
+#define MCS_VCOMDC	0xD900	/* VCOM Voltage Setting */
+#define MCS_GMCT2_2P	0xE100	/* Gamma Correction 2.2+ Setting */
+#define MCS_GMCT2_2N	0xE200	/* Gamma Correction 2.2- Setting */
+#define MCS_NO_DOC3	0xF5B6	/* Command not documented */
+#define MCS_CMD2_ENA1	0xFF00	/* Enable Access Command2 "CMD2" */
+#define MCS_CMD2_ENA2	0xFF80	/* Enable Access Orise Command2 */

--- a/TFT_Drivers/NT35510_Defines.h
+++ b/TFT_Drivers/NT35510_Defines.h
@@ -1,81 +1,71 @@
 // Change the width and height if required (defined in portrait mode)
 // or use the constructor to over-ride defaults
-#define TFT_WIDTH  800
-#define TFT_HEIGHT 480
+#define TFT_WIDTH  480
+#define TFT_HEIGHT 800
 
 // Delay between some initialisation commands
 #define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
 
 // Generic commands used by TFT_eSPI.cpp
-#define TFT_NOP     0x00
-#define TFT_SWRST   0x01
+#define TFT_NOP     0x0000
+#define TFT_SWRST   0x0100
 
-#define TFT_SLPIN   0x10
-#define TFT_SLPOUT  0x11
+#define TFT_SLPIN   0x1000
+#define TFT_SLPOUT  0x1100
 
-#define TFT_INVOFF  0x20
-#define TFT_INVON   0x21
+#define TFT_INVOFF  0x2000
+#define TFT_INVON   0x2100
 
-#define TFT_DISPOFF 0x28
-#define TFT_DISPON  0x29
+#define TFT_DISPOFF 0x2800
+#define TFT_DISPON  0x2900
 
-#define TFT_CASET   0x2A
-#define TFT_PASET   0x2B
-#define TFT_RAMWR   0x2C
+#define TFT_CASET   0x2A00
+#define TFT_PASET   0x2B00
 
-#define TFT_RAMRD   0x2E
+#define TFT_RAMWR   0x2C00
+#define TFT_RAMRD   0x2E00
 
-#define TFT_MADCTL  0x36
+#define TFT_MADCTL  0x3600
 
-#define TFT_MAD_MY  0x80
-#define TFT_MAD_MX  0x40
-#define TFT_MAD_MV  0x20
-#define TFT_MAD_ML  0x10
-#define TFT_MAD_RGB 0x00
-#define TFT_MAD_BGR 0x08
-//#define TFT_MAD_MH  0x04
-//#define TFT_MAD_SS  0x02
-//#define TFT_MAD_GS  0x01
+#define TFT_MAD_MY  0x80 /* Row Address Order */
+#define TFT_MAD_MX  0x40 /* Column Address Order */
+#define TFT_MAD_MV  0x20 /* Row / Column Exchange */
+#define TFT_MAD_ML  0x10 /* Vertical Refresh Order - Bottom to Top */
 
-/* Manufacturer Command Set */
-#define MCS_ADRSFT	0x0000	/* Address Shift Function */
-#define MCS_PANSET	0xB3A6	/* Panel Type Setting */
-#define MCS_SD_CTRL	0xC0A2	/* Source Driver Timing Setting */
-#define MCS_P_DRV_M	0xC0B4	/* Panel Driving Mode */
-#define MCS_OSC_ADJ	0xC181	/* Oscillator Adjustment for Idle/Normal mode */
-#define MCS_RGB_VID_SET	0xC1A1	/* RGB Video Mode Setting */
-#define MCS_SD_PCH_CTRL	0xC480	/* Source Driver Precharge Control */
-#define MCS_NO_DOC1	0xC48A	/* Command not documented */
-#define MCS_PWR_CTRL1	0xC580	/* Power Control Setting 1 */
-#define MCS_PWR_CTRL2	0xC590	/* Power Control Setting 2 for Normal Mode */
-#define MCS_PWR_CTRL4	0xC5B0	/* Power Control Setting 4 for DC Voltage */
-#define MCS_PANCTRLSET1	0xCB80	/* Panel Control Setting 1 */
-#define MCS_PANCTRLSET2	0xCB90	/* Panel Control Setting 2 */
-#define MCS_PANCTRLSET3	0xCBA0	/* Panel Control Setting 3 */
-#define MCS_PANCTRLSET4	0xCBB0	/* Panel Control Setting 4 */
-#define MCS_PANCTRLSET5	0xCBC0	/* Panel Control Setting 5 */
-#define MCS_PANCTRLSET6	0xCBD0	/* Panel Control Setting 6 */
-#define MCS_PANCTRLSET7	0xCBE0	/* Panel Control Setting 7 */
-#define MCS_PANCTRLSET8	0xCBF0	/* Panel Control Setting 8 */
-#define MCS_PANU2D1	0xCC80	/* Panel U2D Setting 1 */
-#define MCS_PANU2D2	0xCC90	/* Panel U2D Setting 2 */
-#define MCS_PANU2D3	0xCCA0	/* Panel U2D Setting 3 */
-#define MCS_PAND2U1	0xCCB0	/* Panel D2U Setting 1 */
-#define MCS_PAND2U2	0xCCC0	/* Panel D2U Setting 2 */
-#define MCS_PAND2U3	0xCCD0	/* Panel D2U Setting 3 */
-#define MCS_GOAVST	0xCE80	/* GOA VST Setting */
-#define MCS_GOACLKA1	0xCEA0	/* GOA CLKA1 Setting */
-#define MCS_GOACLKA2	0xCEA7	/* GOA CLKA2 Setting */
-#define MCS_GOACLKA3	0xCEB0	/* GOA CLKA3 Setting */
-#define MCS_GOACLKA4	0xCEB7	/* GOA CLKA4 Setting */
-#define MCS_GOAECLK		0xCFC0	/* GOA ECLK Setting */
-#define MCS_GOAOPT1		0xCFC6	/* GOA Other Options 1 */
-#define MCS_GOATGOPT	0xCFC7	/* GOA Signal Toggle Option Setting */
-#define MCS_NO_DOC2	0xCFD0	/* Command not documented */
-#define MCS_GVDDSET	0xD800	/* GVDD/NGVDD */
-#define MCS_VCOMDC	0xD900	/* VCOM Voltage Setting */
-#define MCS_GMCT2_2P	0xE100	/* Gamma Correction 2.2+ Setting */
-#define MCS_GMCT2_2N	0xE200	/* Gamma Correction 2.2- Setting */
-#define MCS_NO_DOC3	0xF5B6	/* Command not documented */
-#define MCS_CMD2_ENA1	0xFF00	/* Enable Access Command2 "CMD2" */
-#define MCS_CMD2_ENA2	0xFF80	/* Enable Access Orise Command2 */
+#define TFT_MAD_RGB 0x00 /* RGB color filter panel */
+#define TFT_MAD_BGR 0x08 /* BGR color filter panel */
+
+#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
+#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
+
+#define TFT_CASET_CMD(x0, x1) \
+  DC_C; tft_Write_16(TFT_CASET); \
+  DC_D; tft_Write_16(Byte8H(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 1); \
+  DC_D; tft_Write_16(Byte8L(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 2); \
+  DC_D; tft_Write_16(Byte8H(x1)); \
+  DC_C; tft_Write_16(TFT_CASET + 3); \
+  DC_D; tft_Write_16(Byte8L(x1))
+
+#define TFT_PASET_CMD(y0, y1) \
+  DC_C; tft_Write_16(TFT_PASET); \
+  DC_D; tft_Write_16(Byte8H(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 1); \
+  DC_D; tft_Write_16(Byte8L(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 2); \
+  DC_D; tft_Write_16(Byte8H(y1)); \
+  DC_C; tft_Write_16(TFT_PASET + 3); \
+  DC_D; tft_Write_16(Byte8L(y1))
+
+#define TFT_RAMWR_CMD \
+  DC_C; tft_Write_16(TFT_RAMWR)
+
+#define TFT_RAMRD_CMD \
+  DC_C; tft_Write_16(TFT_RAMRD)
+
+#define writecommand16(cmd) \
+	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
+
+#define writedata16(data) \
+	writedata(Byte8H(data)); writedata(Byte8L(data))

--- a/TFT_Drivers/NT35510_Init.h
+++ b/TFT_Drivers/NT35510_Init.h
@@ -1,27 +1,502 @@
-
 // This is the command sequence that initialises the NT35510 driver
-// Configure NT35510 display
 
-#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
-#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
+//************* NT35510初始化**********//	
+	/* MAUCCTR: Manufacture Command Set enable */
+	//#Enable Page1
+	writecommand16(0xF000); writedata16(0x55);
+	writecommand16(0xF001); writedata16(0xAA);
+	writecommand16(0xF002); writedata16(0x52);
+	writecommand16(0xF003); writedata16(0x08);
+	writecommand16(0xF004); writedata16(0x01);
+	
+	/* BT1CTR: BT1 Power Control for AVDD */
+	//# AVDD: manual); 
+	writecommand16(0xB600); writedata16(0x34);
+	writecommand16(0xB601); writedata16(0x34);
+	writecommand16(0xB602); writedata16(0x34);
 
-#ifndef TFT_CASET_CMD
-	#define TFT_CASET_CMD(x0, x1) \
-		DC_C; tft_Write_8(TFT_CASET); \
-		DC_D; tft_Write_32C(x0, x1)
-#endif
+	/* SETAVDD: Setting AVDD Voltage */
+	writecommand16(0xB000); writedata16(0x0D);//09
+	writecommand16(0xB001); writedata16(0x0D);
+	writecommand16(0xB002); writedata16(0x0D);
+	
+	/* BT2CTR: BT2 Power Control for AVEE */
+	//# AVEE: manual); -6V
+	writecommand16(0xB700); writedata16(0x24);
+	writecommand16(0xB701); writedata16(0x24);
+	writecommand16(0xB702); writedata16(0x24);
 
-#ifndef TFT_PASET_CMD
-	#define TFT_PASET_CMD(y0, y1) \
-		DC_C; tft_Write_8(TFT_PASET); \
-		DC_D; tft_Write_32C(y0, y1)
-#endif
+	/* SETAVEE: Setting AVEE Voltage */
+	writecommand16(0xB100); writedata16(0x0D);
+	writecommand16(0xB101); writedata16(0x0D);
+	writecommand16(0xB102); writedata16(0x0D);
+	
+	/* BT3CTR: BT3 Power Control for VCL */
+	writecommand16(0xB800); writedata16(0x24);
+	writecommand16(0xB801); writedata16(0x24);
+	writecommand16(0xB802); writedata16(0x24);
 
-#define writecommand16(cmd) \
-	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
+	/* SETVCL: Setting VCL Voltage */
+	writecommand16(0xB200); writedata16(0x00);
 
-#define writedata16(data) \
-	writedata(Byte8H(data)); writedata(Byte8L(data))
+	/* BT4CTR: BT4 Power Control for VGH */
+	//# VGH: Clamp Enable); 
+	writecommand16(0xB900); writedata16(0x24);
+	writecommand16(0xB901); writedata16(0x24);
+	writecommand16(0xB902); writedata16(0x24);
 
+	/* SETVGH: Setting VGH Voltage */
+	writecommand16(0xB300); writedata16(0x05);
+	writecommand16(0xB301); writedata16(0x05);
+	writecommand16(0xB302); writedata16(0x05);
+
+	/* VGHCTR: VGH Output Voltage - commented out */
+	///writecommand16(0xBF00); writedata16(0x01);
+
+	/* BT5CTR: BT5 Power Control for VGLX */
+	//# VGL(LVGL):
+	writecommand16(0xBA00); writedata16(0x34);
+	writecommand16(0xBA01); writedata16(0x34);
+	writecommand16(0xBA02); writedata16(0x34);
+
+	/* SETVGL_REG: Setting VGL_REG Voltage */
+	//# VGL_REG(VGLO)
+	writecommand16(0xB500); writedata16(0x0B);
+	writecommand16(0xB501); writedata16(0x0B);
+	writecommand16(0xB502); writedata16(0x0B);
+
+	/* SETVGP: Setting VGMP and VGSP Voltage */
+	//# VGMP/VGSP:
+	writecommand16(0xBC00); writedata16(0X00);
+	writecommand16(0xBC01); writedata16(0xA3);
+	writecommand16(0xBC02); writedata16(0X00);
+
+	/* SETVGN: Setting VGMN and VGSN Voltage */
+	//# VGMN/VGSN
+	writecommand16(0xBD00); writedata16(0x00);
+	writecommand16(0xBD01); writedata16(0xA3);
+	writecommand16(0xBD02); writedata16(0x00);
+
+	/* SETVCMOFF: Setting VCOM Offset Voltage */
+	//# VCOM=-0.1
+	writecommand16(0xBE00); writedata16(0x00);
+	writecommand16(0xBE01); writedata16(0x63);//4f
+	//  VCOMH+0x01;
+  
+  	/* GMRCTR1: Setting Gamma 2.2 Correction for Red (Positive) */
+	//#R+
+	writecommand16(0xD100); writedata16(0x00);
+	writecommand16(0xD101); writedata16(0x37);
+	writecommand16(0xD102); writedata16(0x00);
+	writecommand16(0xD103); writedata16(0x52);
+	writecommand16(0xD104); writedata16(0x00);
+	writecommand16(0xD105); writedata16(0x7B);
+	writecommand16(0xD106); writedata16(0x00);
+	writecommand16(0xD107); writedata16(0x99);
+	writecommand16(0xD108); writedata16(0x00);
+	writecommand16(0xD109); writedata16(0xB1);
+	writecommand16(0xD10A); writedata16(0x00);
+	writecommand16(0xD10B); writedata16(0xD2);
+	writecommand16(0xD10C); writedata16(0x00);
+	writecommand16(0xD10D); writedata16(0xF6);
+	writecommand16(0xD10E); writedata16(0x01);
+	writecommand16(0xD10F); writedata16(0x27);
+	writecommand16(0xD110); writedata16(0x01);
+	writecommand16(0xD111); writedata16(0x4E);
+	writecommand16(0xD112); writedata16(0x01);
+	writecommand16(0xD113); writedata16(0x8C);
+	writecommand16(0xD114); writedata16(0x01);
+	writecommand16(0xD115); writedata16(0xBE);
+	writecommand16(0xD116); writedata16(0x02);
+	writecommand16(0xD117); writedata16(0x0B);
+	writecommand16(0xD118); writedata16(0x02);
+	writecommand16(0xD119); writedata16(0x48);
+	writecommand16(0xD11A); writedata16(0x02);
+	writecommand16(0xD11B); writedata16(0x4A);
+	writecommand16(0xD11C); writedata16(0x02);
+	writecommand16(0xD11D); writedata16(0x7E);
+	writecommand16(0xD11E); writedata16(0x02);
+	writecommand16(0xD11F); writedata16(0xBC);
+	writecommand16(0xD120); writedata16(0x02);
+	writecommand16(0xD121); writedata16(0xE1);
+	writecommand16(0xD122); writedata16(0x03);
+	writecommand16(0xD123); writedata16(0x10);
+	writecommand16(0xD124); writedata16(0x03);
+	writecommand16(0xD125); writedata16(0x31);
+	writecommand16(0xD126); writedata16(0x03);
+	writecommand16(0xD127); writedata16(0x5A);
+	writecommand16(0xD128); writedata16(0x03);
+	writecommand16(0xD129); writedata16(0x73);
+	writecommand16(0xD12A); writedata16(0x03);
+	writecommand16(0xD12B); writedata16(0x94);
+	writecommand16(0xD12C); writedata16(0x03);
+	writecommand16(0xD12D); writedata16(0x9F);
+	writecommand16(0xD12E); writedata16(0x03);
+	writecommand16(0xD12F); writedata16(0xB3);
+	writecommand16(0xD130); writedata16(0x03);
+	writecommand16(0xD131); writedata16(0xB9);
+	writecommand16(0xD132); writedata16(0x03);
+	writecommand16(0xD133); writedata16(0xC1);
+	
+	/* GMGCTR1: Setting Gamma 2.2 Correction for Green (Positive) */
+	//#G+
+	writecommand16(0xD200); writedata16(0x00);
+	writecommand16(0xD201); writedata16(0x37);
+	writecommand16(0xD202); writedata16(0x00);
+	writecommand16(0xD203); writedata16(0x52);
+	writecommand16(0xD204); writedata16(0x00);
+	writecommand16(0xD205); writedata16(0x7B);
+	writecommand16(0xD206); writedata16(0x00);
+	writecommand16(0xD207); writedata16(0x99);
+	writecommand16(0xD208); writedata16(0x00);
+	writecommand16(0xD209); writedata16(0xB1);
+	writecommand16(0xD20A); writedata16(0x00);
+	writecommand16(0xD20B); writedata16(0xD2);
+	writecommand16(0xD20C); writedata16(0x00);
+	writecommand16(0xD20D); writedata16(0xF6);
+	writecommand16(0xD20E); writedata16(0x01);
+	writecommand16(0xD20F); writedata16(0x27);
+	writecommand16(0xD210); writedata16(0x01);
+	writecommand16(0xD211); writedata16(0x4E);
+	writecommand16(0xD212); writedata16(0x01);
+	writecommand16(0xD213); writedata16(0x8C);
+	writecommand16(0xD214); writedata16(0x01);
+	writecommand16(0xD215); writedata16(0xBE);
+	writecommand16(0xD216); writedata16(0x02);
+	writecommand16(0xD217); writedata16(0x0B);
+	writecommand16(0xD218); writedata16(0x02);
+	writecommand16(0xD219); writedata16(0x48);
+	writecommand16(0xD21A); writedata16(0x02);
+	writecommand16(0xD21B); writedata16(0x4A);
+	writecommand16(0xD21C); writedata16(0x02);
+	writecommand16(0xD21D); writedata16(0x7E);
+	writecommand16(0xD21E); writedata16(0x02);
+	writecommand16(0xD21F); writedata16(0xBC);
+	writecommand16(0xD220); writedata16(0x02);
+	writecommand16(0xD221); writedata16(0xE1);
+	writecommand16(0xD222); writedata16(0x03);
+	writecommand16(0xD223); writedata16(0x10);
+	writecommand16(0xD224); writedata16(0x03);
+	writecommand16(0xD225); writedata16(0x31);
+	writecommand16(0xD226); writedata16(0x03);
+	writecommand16(0xD227); writedata16(0x5A);
+	writecommand16(0xD228); writedata16(0x03);
+	writecommand16(0xD229); writedata16(0x73);
+	writecommand16(0xD22A); writedata16(0x03);
+	writecommand16(0xD22B); writedata16(0x94);
+	writecommand16(0xD22C); writedata16(0x03);
+	writecommand16(0xD22D); writedata16(0x9F);
+	writecommand16(0xD22E); writedata16(0x03);
+	writecommand16(0xD22F); writedata16(0xB3);
+	writecommand16(0xD230); writedata16(0x03);
+	writecommand16(0xD231); writedata16(0xB9);
+	writecommand16(0xD232); writedata16(0x03);
+	writecommand16(0xD233); writedata16(0xC1);
+	
+	/* GMBCTR1: Setting Gamma 2.2 Correction for Blue (Positive) */
+	//#B+
+	writecommand16(0xD300); writedata16(0x00);
+	writecommand16(0xD301); writedata16(0x37);
+	writecommand16(0xD302); writedata16(0x00);
+	writecommand16(0xD303); writedata16(0x52);
+	writecommand16(0xD304); writedata16(0x00);
+	writecommand16(0xD305); writedata16(0x7B);
+	writecommand16(0xD306); writedata16(0x00);
+	writecommand16(0xD307); writedata16(0x99);
+	writecommand16(0xD308); writedata16(0x00);
+	writecommand16(0xD309); writedata16(0xB1);
+	writecommand16(0xD30A); writedata16(0x00);
+	writecommand16(0xD30B); writedata16(0xD2);
+	writecommand16(0xD30C); writedata16(0x00);
+	writecommand16(0xD30D); writedata16(0xF6);
+	writecommand16(0xD30E); writedata16(0x01);
+	writecommand16(0xD30F); writedata16(0x27);
+	writecommand16(0xD310); writedata16(0x01);
+	writecommand16(0xD311); writedata16(0x4E);
+	writecommand16(0xD312); writedata16(0x01);
+	writecommand16(0xD313); writedata16(0x8C);
+	writecommand16(0xD314); writedata16(0x01);
+	writecommand16(0xD315); writedata16(0xBE);
+	writecommand16(0xD316); writedata16(0x02);
+	writecommand16(0xD317); writedata16(0x0B);
+	writecommand16(0xD318); writedata16(0x02);
+	writecommand16(0xD319); writedata16(0x48);
+	writecommand16(0xD31A); writedata16(0x02);
+	writecommand16(0xD31B); writedata16(0x4A);
+	writecommand16(0xD31C); writedata16(0x02);
+	writecommand16(0xD31D); writedata16(0x7E);
+	writecommand16(0xD31E); writedata16(0x02);
+	writecommand16(0xD31F); writedata16(0xBC);
+	writecommand16(0xD320); writedata16(0x02);
+	writecommand16(0xD321); writedata16(0xE1);
+	writecommand16(0xD322); writedata16(0x03);
+	writecommand16(0xD323); writedata16(0x10);
+	writecommand16(0xD324); writedata16(0x03);
+	writecommand16(0xD325); writedata16(0x31);
+	writecommand16(0xD326); writedata16(0x03);
+	writecommand16(0xD327); writedata16(0x5A);
+	writecommand16(0xD328); writedata16(0x03);
+	writecommand16(0xD329); writedata16(0x73);
+	writecommand16(0xD32A); writedata16(0x03);
+	writecommand16(0xD32B); writedata16(0x94);
+	writecommand16(0xD32C); writedata16(0x03);
+	writecommand16(0xD32D); writedata16(0x9F);
+	writecommand16(0xD32E); writedata16(0x03);
+	writecommand16(0xD32F); writedata16(0xB3);
+	writecommand16(0xD330); writedata16(0x03);
+	writecommand16(0xD331); writedata16(0xB9);
+	writecommand16(0xD332); writedata16(0x03);
+	writecommand16(0xD333); writedata16(0xC1);
+
+	/* GMRCTR2: Setting Gamma 2.2 Correction for Red (Negative) */
+	//#R-///////////////////////////////////////////
+	writecommand16(0xD400); writedata16(0x00);
+	writecommand16(0xD401); writedata16(0x37);
+	writecommand16(0xD402); writedata16(0x00);
+	writecommand16(0xD403); writedata16(0x52);
+	writecommand16(0xD404); writedata16(0x00);
+	writecommand16(0xD405); writedata16(0x7B);
+	writecommand16(0xD406); writedata16(0x00);
+	writecommand16(0xD407); writedata16(0x99);
+	writecommand16(0xD408); writedata16(0x00);
+	writecommand16(0xD409); writedata16(0xB1);
+	writecommand16(0xD40A); writedata16(0x00);
+	writecommand16(0xD40B); writedata16(0xD2);
+	writecommand16(0xD40C); writedata16(0x00);
+	writecommand16(0xD40D); writedata16(0xF6);
+	writecommand16(0xD40E); writedata16(0x01);
+	writecommand16(0xD40F); writedata16(0x27);
+	writecommand16(0xD410); writedata16(0x01);
+	writecommand16(0xD411); writedata16(0x4E);
+	writecommand16(0xD412); writedata16(0x01);
+	writecommand16(0xD413); writedata16(0x8C);
+	writecommand16(0xD414); writedata16(0x01);
+	writecommand16(0xD415); writedata16(0xBE);
+	writecommand16(0xD416); writedata16(0x02);
+	writecommand16(0xD417); writedata16(0x0B);
+	writecommand16(0xD418); writedata16(0x02);
+	writecommand16(0xD419); writedata16(0x48);
+	writecommand16(0xD41A); writedata16(0x02);
+	writecommand16(0xD41B); writedata16(0x4A);
+	writecommand16(0xD41C); writedata16(0x02);
+	writecommand16(0xD41D); writedata16(0x7E);
+	writecommand16(0xD41E); writedata16(0x02);
+	writecommand16(0xD41F); writedata16(0xBC);
+	writecommand16(0xD420); writedata16(0x02);
+	writecommand16(0xD421); writedata16(0xE1);
+	writecommand16(0xD422); writedata16(0x03);
+	writecommand16(0xD423); writedata16(0x10);
+	writecommand16(0xD424); writedata16(0x03);
+	writecommand16(0xD425); writedata16(0x31);
+	writecommand16(0xD426); writedata16(0x03);
+	writecommand16(0xD427); writedata16(0x5A);
+	writecommand16(0xD428); writedata16(0x03);
+	writecommand16(0xD429); writedata16(0x73);
+	writecommand16(0xD42A); writedata16(0x03);
+	writecommand16(0xD42B); writedata16(0x94);
+	writecommand16(0xD42C); writedata16(0x03);
+	writecommand16(0xD42D); writedata16(0x9F);
+	writecommand16(0xD42E); writedata16(0x03);
+	writecommand16(0xD42F); writedata16(0xB3);
+	writecommand16(0xD430); writedata16(0x03);
+	writecommand16(0xD431); writedata16(0xB9);
+	writecommand16(0xD432); writedata16(0x03);
+	writecommand16(0xD433); writedata16(0xC1);
+
+	/* GMGCTR2: Setting Gamma 2.2 Correction for Green (Negative) */
+	//#G-//////////////////////////////////////////////
+	writecommand16(0xD500); writedata16(0x00);
+	writecommand16(0xD501); writedata16(0x37);
+	writecommand16(0xD502); writedata16(0x00);
+	writecommand16(0xD503); writedata16(0x52);
+	writecommand16(0xD504); writedata16(0x00);
+	writecommand16(0xD505); writedata16(0x7B);
+	writecommand16(0xD506); writedata16(0x00);
+	writecommand16(0xD507); writedata16(0x99);
+	writecommand16(0xD508); writedata16(0x00);
+	writecommand16(0xD509); writedata16(0xB1);
+	writecommand16(0xD50A); writedata16(0x00);
+	writecommand16(0xD50B); writedata16(0xD2);
+	writecommand16(0xD50C); writedata16(0x00);
+	writecommand16(0xD50D); writedata16(0xF6);
+	writecommand16(0xD50E); writedata16(0x01);
+	writecommand16(0xD50F); writedata16(0x27);
+	writecommand16(0xD510); writedata16(0x01);
+	writecommand16(0xD511); writedata16(0x4E);
+	writecommand16(0xD512); writedata16(0x01);
+	writecommand16(0xD513); writedata16(0x8C);
+	writecommand16(0xD514); writedata16(0x01);
+	writecommand16(0xD515); writedata16(0xBE);
+	writecommand16(0xD516); writedata16(0x02);
+	writecommand16(0xD517); writedata16(0x0B);
+	writecommand16(0xD518); writedata16(0x02);
+	writecommand16(0xD519); writedata16(0x48);
+	writecommand16(0xD51A); writedata16(0x02);
+	writecommand16(0xD51B); writedata16(0x4A);
+	writecommand16(0xD51C); writedata16(0x02);
+	writecommand16(0xD51D); writedata16(0x7E);
+	writecommand16(0xD51E); writedata16(0x02);
+	writecommand16(0xD51F); writedata16(0xBC);
+	writecommand16(0xD520); writedata16(0x02);
+	writecommand16(0xD521); writedata16(0xE1);
+	writecommand16(0xD522); writedata16(0x03);
+	writecommand16(0xD523); writedata16(0x10);
+	writecommand16(0xD524); writedata16(0x03);
+	writecommand16(0xD525); writedata16(0x31);
+	writecommand16(0xD526); writedata16(0x03);
+	writecommand16(0xD527); writedata16(0x5A);
+	writecommand16(0xD528); writedata16(0x03);
+	writecommand16(0xD529); writedata16(0x73);
+	writecommand16(0xD52A); writedata16(0x03);
+	writecommand16(0xD52B); writedata16(0x94);
+	writecommand16(0xD52C); writedata16(0x03);
+	writecommand16(0xD52D); writedata16(0x9F);
+	writecommand16(0xD52E); writedata16(0x03);
+	writecommand16(0xD52F); writedata16(0xB3);
+	writecommand16(0xD530); writedata16(0x03);
+	writecommand16(0xD531); writedata16(0xB9);
+	writecommand16(0xD532); writedata16(0x03);
+	writecommand16(0xD533); writedata16(0xC1);
+	
+	/* GMBCTR2: Setting Gamma 2.2 Correction for Blue (Negative) */
+	//#B-///////////////////////////////
+	writecommand16(0xD600); writedata16(0x00);
+	writecommand16(0xD601); writedata16(0x37);
+	writecommand16(0xD602); writedata16(0x00);
+	writecommand16(0xD603); writedata16(0x52);
+	writecommand16(0xD604); writedata16(0x00);
+	writecommand16(0xD605); writedata16(0x7B);
+	writecommand16(0xD606); writedata16(0x00);
+	writecommand16(0xD607); writedata16(0x99);
+	writecommand16(0xD608); writedata16(0x00);
+	writecommand16(0xD609); writedata16(0xB1);
+	writecommand16(0xD60A); writedata16(0x00);
+	writecommand16(0xD60B); writedata16(0xD2);
+	writecommand16(0xD60C); writedata16(0x00);
+	writecommand16(0xD60D); writedata16(0xF6);
+	writecommand16(0xD60E); writedata16(0x01);
+	writecommand16(0xD60F); writedata16(0x27);
+	writecommand16(0xD610); writedata16(0x01);
+	writecommand16(0xD611); writedata16(0x4E);
+	writecommand16(0xD612); writedata16(0x01);
+	writecommand16(0xD613); writedata16(0x8C);
+	writecommand16(0xD614); writedata16(0x01);
+	writecommand16(0xD615); writedata16(0xBE);
+	writecommand16(0xD616); writedata16(0x02);
+	writecommand16(0xD617); writedata16(0x0B);
+	writecommand16(0xD618); writedata16(0x02);
+	writecommand16(0xD619); writedata16(0x48);
+	writecommand16(0xD61A); writedata16(0x02);
+	writecommand16(0xD61B); writedata16(0x4A);
+	writecommand16(0xD61C); writedata16(0x02);
+	writecommand16(0xD61D); writedata16(0x7E);
+	writecommand16(0xD61E); writedata16(0x02);
+	writecommand16(0xD61F); writedata16(0xBC);
+	writecommand16(0xD620); writedata16(0x02);
+	writecommand16(0xD621); writedata16(0xE1);
+	writecommand16(0xD622); writedata16(0x03);
+	writecommand16(0xD623); writedata16(0x10);
+	writecommand16(0xD624); writedata16(0x03);
+	writecommand16(0xD625); writedata16(0x31);
+	writecommand16(0xD626); writedata16(0x03);
+	writecommand16(0xD627); writedata16(0x5A);
+	writecommand16(0xD628); writedata16(0x03);
+	writecommand16(0xD629); writedata16(0x73);
+	writecommand16(0xD62A); writedata16(0x03);
+	writecommand16(0xD62B); writedata16(0x94);
+	writecommand16(0xD62C); writedata16(0x03);
+	writecommand16(0xD62D); writedata16(0x9F);
+	writecommand16(0xD62E); writedata16(0x03);
+	writecommand16(0xD62F); writedata16(0xB3);
+	writecommand16(0xD630); writedata16(0x03);
+	writecommand16(0xD631); writedata16(0xB9);
+	writecommand16(0xD632); writedata16(0x03);
+	writecommand16(0xD633); writedata16(0xC1);
+
+	/* MAUCCTR: Manufacture Command Set enable */
+	//#Enable Page0
+	writecommand16(0xF000); writedata16(0x55);
+	writecommand16(0xF001); writedata16(0xAA);
+	writecommand16(0xF002); writedata16(0x52);
+	writecommand16(0xF003); writedata16(0x08);
+	writecommand16(0xF004); writedata16(0x00);
+	
+	/* RGBCTR: RGB Interface Signals Control */
+	//# RGB I/F Setting
+	writecommand16(0xB000); writedata16(0x08);
+	writecommand16(0xB001); writedata16(0x05);
+	writecommand16(0xB002); writedata16(0x02);
+	writecommand16(0xB003); writedata16(0x05);
+	writecommand16(0xB004); writedata16(0x02);
+	
+	/* SDHDTCTR: Source Output Data Hold Time Control */
+	//## SDT:
+	writecommand16(0xB600); writedata16(0x08);
+
+	/* DPRSLCTR: Display Resolution Control */
+	writecommand16(0xB500); writedata16(0x50);//0x6b ???? 480x854       0x50 ???? 480x800
+
+	/* GSEQCTR: EQ Control Function for Gate Signals */
+	//## Gate EQ:
+	writecommand16(0xB700); writedata16(0x00);
+	writecommand16(0xB701); writedata16(0x00);
+
+	/* SDEQCTR: EQ Control Function for Source Driver */
+	//## Source EQ:
+	writecommand16(0xB800); writedata16(0x01);
+	writecommand16(0xB801); writedata16(0x05);
+	writecommand16(0xB802); writedata16(0x05);
+	writecommand16(0xB803); writedata16(0x05);
+
+	/* INVCTR: Inversion Driving Control */
+	//# Inversion: Column inversion (NVT)
+	writecommand16(0xBC00); writedata16(0x00);
+	writecommand16(0xBC01); writedata16(0x00);
+	writecommand16(0xBC02); writedata16(0x00);
+
+	/* DPTMCTR12: Display Timing Control 12 */
+	//# BOE's Setting(default)
+	writecommand16(0xCC00); writedata16(0x03);
+	writecommand16(0xCC01); writedata16(0x00);
+	writecommand16(0xCC02); writedata16(0x00);
+
+	/* DPFRCTR1: Display Timing Control in Normal / Idle Off Mode */
+	//# Display Timing:
+	writecommand16(0xBD00); writedata16(0x01);
+	writecommand16(0xBD01); writedata16(0x84);
+	writecommand16(0xBD02); writedata16(0x07);
+	writecommand16(0xBD03); writedata16(0x31);
+	writecommand16(0xBD04); writedata16(0x00);
+
+	/* SDVPCTR: Source Control in Vertical Porch Time */
+	writecommand16(0xBA00); writedata16(0x01);
+
+	/* MAUCCTR: Manufacture Command Set disable (?) */
+	writecommand16(0xFF00); writedata16(0xAA);
+	writecommand16(0xFF01); writedata16(0x55);
+	writecommand16(0xFF02); writedata16(0x25);
+	writecommand16(0xFF03); writedata16(0x01);
+
+	/* TEON: Tearing Effect Line ON */
+	writecommand16(0x3500); writedata16(0x00);
+
+	/* MADCTL: Memory Data Access Control */
+	writecommand16(TFT_MADCTL); writedata16(0x00);
+
+	/* COLMOD: Interface Pixel Format */ 
+	/* 	“0101” = 16-bit/pixel
+		“0110” = 18-bit/pixel
+		“0111” = 24-bit/pixel */
+	writecommand16(0x3a00); writedata16(0x55);  ////55=16?/////66=18?
+	
+	/* SLPOUT: Sleep Out */
+	writecommand16(TFT_SLPOUT);	
+	delay(120); 
+
+	/* DISPON: Display On */
+	writecommand16(TFT_DISPON); 
+	
+	/* RAMWR: Memory Write */
+	//writecommand16(TFT_RAMWR);
 
 // End of NT35510 display configuration

--- a/TFT_Drivers/NT35510_Init.h
+++ b/TFT_Drivers/NT35510_Init.h
@@ -1,0 +1,27 @@
+
+// This is the command sequence that initialises the NT35510 driver
+// Configure NT35510 display
+
+#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
+#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
+
+#ifndef TFT_CASET_CMD
+	#define TFT_CASET_CMD(x0, x1) \
+		DC_C; tft_Write_8(TFT_CASET); \
+		DC_D; tft_Write_32C(x0, x1)
+#endif
+
+#ifndef TFT_PASET_CMD
+	#define TFT_PASET_CMD(y0, y1) \
+		DC_C; tft_Write_8(TFT_PASET); \
+		DC_D; tft_Write_32C(y0, y1)
+#endif
+
+#define writecommand16(cmd) \
+	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
+
+#define writedata16(data) \
+	writedata(Byte8H(data)); writedata(Byte8L(data))
+
+
+// End of NT35510 display configuration

--- a/TFT_Drivers/NT35510_Rotation.h
+++ b/TFT_Drivers/NT35510_Rotation.h
@@ -1,32 +1,26 @@
   // This is the command sequence that rotates the NT35510 driver coordinate frame
-
   rotation = m % 4;
-  writecommand(TFT_MADCTL);
-  writecommand(TFT_NOP);
+  writecommand16(TFT_MADCTL);
+
   switch (rotation) {
    case 0: // Portrait
+      writedata16(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-      writedata(0x00);
-      writedata(0x00);
+      _height = TFT_HEIGHT;      
      break;
    case 1: // Landscape (Portrait + 90)
+      writedata16(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
-      writedata((1<<5)|(1<<6));
-      writedata(0x00);
+      _height = TFT_WIDTH;      
      break;
    case 2: // Inverter portrait
+      writedata16(TFT_MAD_RGB);
       _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-      writedata((1<<7)|(1<<6));
-      writedata(0x00);
+      _height = TFT_HEIGHT;      
      break;
    case 3: // Inverted landscape
+      writedata16(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
-      
-      writedata((1<<7)|(1<<5));
-      writedata(0x00);
      break;
   }

--- a/TFT_Drivers/NT35510_Rotation.h
+++ b/TFT_Drivers/NT35510_Rotation.h
@@ -1,0 +1,32 @@
+  // This is the command sequence that rotates the NT35510 driver coordinate frame
+
+  rotation = m % 4;
+  writecommand(TFT_MADCTL);
+  writecommand(TFT_NOP);
+  switch (rotation) {
+   case 0: // Portrait
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      writedata(0x00);
+      writedata(0x00);
+     break;
+   case 1: // Landscape (Portrait + 90)
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      writedata((1<<5)|(1<<6));
+      writedata(0x00);
+     break;
+   case 2: // Inverter portrait
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      writedata((1<<7)|(1<<6));
+      writedata(0x00);
+     break;
+   case 3: // Inverted landscape
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      
+      writedata((1<<7)|(1<<5));
+      writedata(0x00);
+     break;
+  }

--- a/TFT_Drivers/OTM8009A_Defines.h
+++ b/TFT_Drivers/OTM8009A_Defines.h
@@ -7,25 +7,25 @@
 #define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
 
 // Generic commands used by TFT_eSPI.cpp
-#define TFT_NOP     0x00
-#define TFT_SWRST   0x01
+#define TFT_NOP     0x0000
+#define TFT_SWRST   0x0100
 
-#define TFT_SLPIN   0x10
-#define TFT_SLPOUT  0x11
+#define TFT_SLPIN   0x1000
+#define TFT_SLPOUT  0x1100
 
-#define TFT_INVOFF  0x20
-#define TFT_INVON   0x21
+#define TFT_INVOFF  0x2000
+#define TFT_INVON   0x2100
 
-#define TFT_DISPOFF 0x28
-#define TFT_DISPON  0x29
+#define TFT_DISPOFF 0x2800
+#define TFT_DISPON  0x2900
 
 #define TFT_CASET   0x2A00
 #define TFT_PASET   0x2B00
 
-#define TFT_RAMWR   0x2C
-#define TFT_RAMRD   0x2E
+#define TFT_RAMWR   0x2C00
+#define TFT_RAMRD   0x2E00
 
-#define TFT_MADCTL  0x36
+#define TFT_MADCTL  0x3600
 
 #define TFT_MAD_MY  0x80 /* Row Address Order */
 #define TFT_MAD_MX  0x40 /* Column Address Order */
@@ -100,6 +100,12 @@
   DC_D; tft_Write_16(Byte8H(y1)); \
   DC_C; tft_Write_16(TFT_PASET + 3); \
   DC_D; tft_Write_16(Byte8L(y1))
+
+#define TFT_RAMWR_CMD \
+  DC_C; tft_Write_16(TFT_RAMWR)
+
+#define TFT_RAMRD_CMD \
+  DC_C; tft_Write_16(TFT_RAMRD)
 
 #define writecommand16(cmd) \
 	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))

--- a/TFT_Drivers/OTM8009A_Defines.h
+++ b/TFT_Drivers/OTM8009A_Defines.h
@@ -19,8 +19,8 @@
 #define TFT_DISPOFF 0x28
 #define TFT_DISPON  0x29
 
-#define TFT_CASET   0x2A
-#define TFT_PASET   0x2B
+#define TFT_CASET   0x2A00
+#define TFT_PASET   0x2B00
 #define TFT_RAMWR   0x2C
 
 #define TFT_RAMRD   0x2E

--- a/TFT_Drivers/OTM8009A_Defines.h
+++ b/TFT_Drivers/OTM8009A_Defines.h
@@ -1,0 +1,81 @@
+// Change the width and height if required (defined in portrait mode)
+// or use the constructor to over-ride defaults
+#define TFT_WIDTH  800
+#define TFT_HEIGHT 480
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+
+#define TFT_RAMRD   0x2E
+
+#define TFT_MADCTL  0x36
+
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+//#define TFT_MAD_MH  0x04
+//#define TFT_MAD_SS  0x02
+//#define TFT_MAD_GS  0x01
+
+/* Manufacturer Command Set */
+#define MCS_ADRSFT	0x0000	/* Address Shift Function */
+#define MCS_PANSET	0xB3A6	/* Panel Type Setting */
+#define MCS_SD_CTRL	0xC0A2	/* Source Driver Timing Setting */
+#define MCS_P_DRV_M	0xC0B4	/* Panel Driving Mode */
+#define MCS_OSC_ADJ	0xC181	/* Oscillator Adjustment for Idle/Normal mode */
+#define MCS_RGB_VID_SET	0xC1A1	/* RGB Video Mode Setting */
+#define MCS_SD_PCH_CTRL	0xC480	/* Source Driver Precharge Control */
+#define MCS_NO_DOC1	0xC48A	/* Command not documented */
+#define MCS_PWR_CTRL1	0xC580	/* Power Control Setting 1 */
+#define MCS_PWR_CTRL2	0xC590	/* Power Control Setting 2 for Normal Mode */
+#define MCS_PWR_CTRL4	0xC5B0	/* Power Control Setting 4 for DC Voltage */
+#define MCS_PANCTRLSET1	0xCB80	/* Panel Control Setting 1 */
+#define MCS_PANCTRLSET2	0xCB90	/* Panel Control Setting 2 */
+#define MCS_PANCTRLSET3	0xCBA0	/* Panel Control Setting 3 */
+#define MCS_PANCTRLSET4	0xCBB0	/* Panel Control Setting 4 */
+#define MCS_PANCTRLSET5	0xCBC0	/* Panel Control Setting 5 */
+#define MCS_PANCTRLSET6	0xCBD0	/* Panel Control Setting 6 */
+#define MCS_PANCTRLSET7	0xCBE0	/* Panel Control Setting 7 */
+#define MCS_PANCTRLSET8	0xCBF0	/* Panel Control Setting 8 */
+#define MCS_PANU2D1	0xCC80	/* Panel U2D Setting 1 */
+#define MCS_PANU2D2	0xCC90	/* Panel U2D Setting 2 */
+#define MCS_PANU2D3	0xCCA0	/* Panel U2D Setting 3 */
+#define MCS_PAND2U1	0xCCB0	/* Panel D2U Setting 1 */
+#define MCS_PAND2U2	0xCCC0	/* Panel D2U Setting 2 */
+#define MCS_PAND2U3	0xCCD0	/* Panel D2U Setting 3 */
+#define MCS_GOAVST	0xCE80	/* GOA VST Setting */
+#define MCS_GOACLKA1	0xCEA0	/* GOA CLKA1 Setting */
+#define MCS_GOACLKA2	0xCEA7	/* GOA CLKA2 Setting */
+#define MCS_GOACLKA3	0xCEB0	/* GOA CLKA3 Setting */
+#define MCS_GOACLKA4	0xCEB7	/* GOA CLKA4 Setting */
+#define MCS_GOAECLK		0xCFC0	/* GOA ECLK Setting */
+#define MCS_GOAOPT1		0xCFC6	/* GOA Other Options 1 */
+#define MCS_GOATGOPT	0xCFC7	/* GOA Signal Toggle Option Setting */
+#define MCS_NO_DOC2	0xCFD0	/* Command not documented */
+#define MCS_GVDDSET	0xD800	/* GVDD/NGVDD */
+#define MCS_VCOMDC	0xD900	/* VCOM Voltage Setting */
+#define MCS_GMCT2_2P	0xE100	/* Gamma Correction 2.2+ Setting */
+#define MCS_GMCT2_2N	0xE200	/* Gamma Correction 2.2- Setting */
+#define MCS_NO_DOC3	0xF5B6	/* Command not documented */
+#define MCS_CMD2_ENA1	0xFF00	/* Enable Access Command2 "CMD2" */
+#define MCS_CMD2_ENA2	0xFF80	/* Enable Access Orise Command2 */

--- a/TFT_Drivers/OTM8009A_Defines.h
+++ b/TFT_Drivers/OTM8009A_Defines.h
@@ -1,41 +1,39 @@
 // Change the width and height if required (defined in portrait mode)
 // or use the constructor to over-ride defaults
-#define TFT_WIDTH  800
-#define TFT_HEIGHT 480
+#define TFT_WIDTH  480
+#define TFT_HEIGHT 800
 
 // Delay between some initialisation commands
 #define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
 
 // Generic commands used by TFT_eSPI.cpp
-#define TFT_NOP     0x00
-#define TFT_SWRST   0x01
+#define TFT_NOP     0x0000
+#define TFT_SWRST   0x0100
 
-#define TFT_SLPIN   0x10
-#define TFT_SLPOUT  0x11
+#define TFT_SLPIN   0x1000
+#define TFT_SLPOUT  0x1100
 
-#define TFT_INVOFF  0x20
-#define TFT_INVON   0x21
+#define TFT_INVOFF  0x2000
+#define TFT_INVON   0x2100
 
-#define TFT_DISPOFF 0x28
-#define TFT_DISPON  0x29
+#define TFT_DISPOFF 0x2800
+#define TFT_DISPON  0x2900
 
 #define TFT_CASET   0x2A00
 #define TFT_PASET   0x2B00
-#define TFT_RAMWR   0x2C
+#define TFT_RAMWR   0x2C00
 
-#define TFT_RAMRD   0x2E
+#define TFT_RAMRD   0x2E00
 
-#define TFT_MADCTL  0x36
+#define TFT_MADCTL  0x3600
 
-#define TFT_MAD_MY  0x80
-#define TFT_MAD_MX  0x40
-#define TFT_MAD_MV  0x20
-#define TFT_MAD_ML  0x10
-#define TFT_MAD_RGB 0x00
-#define TFT_MAD_BGR 0x08
-//#define TFT_MAD_MH  0x04
-//#define TFT_MAD_SS  0x02
-//#define TFT_MAD_GS  0x01
+#define TFT_MAD_MY  0x80 /* Row Address Order */
+#define TFT_MAD_MX  0x40 /* Column Address Order */
+#define TFT_MAD_MV  0x20 /* Row / Column Exchange */
+#define TFT_MAD_ML  0x10 /* Vertical Refresh Order - Bottom to Top */
+
+#define TFT_MAD_RGB 0x00 /* RGB color filter panel */
+#define TFT_MAD_BGR 0x08 /* BGR color filter panel */
 
 /* Manufacturer Command Set */
 #define MCS_ADRSFT	0x0000	/* Address Shift Function */
@@ -79,3 +77,32 @@
 #define MCS_NO_DOC3	0xF5B6	/* Command not documented */
 #define MCS_CMD2_ENA1	0xFF00	/* Enable Access Command2 "CMD2" */
 #define MCS_CMD2_ENA2	0xFF80	/* Enable Access Orise Command2 */
+
+#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
+#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
+
+#define TFT_CASET_CMD(x0, x1) \
+  DC_C; tft_Write_16(TFT_CASET); \
+  DC_D; tft_Write_16(Byte8H(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 1); \
+  DC_D; tft_Write_16(Byte8L(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 2); \
+  DC_D; tft_Write_16(Byte8H(x1)); \
+  DC_C; tft_Write_16(TFT_CASET + 3); \
+  DC_D; tft_Write_16(Byte8L(x1))
+
+#define TFT_PASET_CMD(y0, y1) \
+  DC_C; tft_Write_16(TFT_PASET); \
+  DC_D; tft_Write_16(Byte8H(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 1); \
+  DC_D; tft_Write_16(Byte8L(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 2); \
+  DC_D; tft_Write_16(Byte8H(y1)); \
+  DC_C; tft_Write_16(TFT_PASET + 3); \
+  DC_D; tft_Write_16(Byte8L(y1))
+
+#define writecommand16(cmd) \
+	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
+
+#define writedata16(data) \
+	writedata(Byte8H(data)); writedata(Byte8L(data))

--- a/TFT_Drivers/OTM8009A_Defines.h
+++ b/TFT_Drivers/OTM8009A_Defines.h
@@ -7,25 +7,25 @@
 #define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
 
 // Generic commands used by TFT_eSPI.cpp
-#define TFT_NOP     0x0000
-#define TFT_SWRST   0x0100
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
 
-#define TFT_SLPIN   0x1000
-#define TFT_SLPOUT  0x1100
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
 
-#define TFT_INVOFF  0x2000
-#define TFT_INVON   0x2100
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
 
-#define TFT_DISPOFF 0x2800
-#define TFT_DISPON  0x2900
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
 
 #define TFT_CASET   0x2A00
 #define TFT_PASET   0x2B00
-#define TFT_RAMWR   0x2C00
 
-#define TFT_RAMRD   0x2E00
+#define TFT_RAMWR   0x2C
+#define TFT_RAMRD   0x2E
 
-#define TFT_MADCTL  0x3600
+#define TFT_MADCTL  0x36
 
 #define TFT_MAD_MY  0x80 /* Row Address Order */
 #define TFT_MAD_MX  0x40 /* Column Address Order */

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -1,5 +1,4 @@
 // This is the command sequence that initialises the OTM8009A driver
-// Configure OTM8009A display
 
 //3.97inch OTM8009 Init 20190116
 	/* Enter CMD2 */
@@ -367,7 +366,7 @@
 	writecommand16(0x3A00);//ccaa[7:0] : reg setting for signal35 selection with u2d mode 
 	writedata16(0x55);//0x55
 			
-	/* Exit CMD2 - new! */
+	/* Exit CMD2 */
 	writecommand16(MCS_CMD2_ENA1);
 	writedata16(0xFF);
 	writecommand16(MCS_CMD2_ENA1 + 1);
@@ -376,13 +375,11 @@
 	writedata16(0xFF);
 	
 	/* Sleep out */
-	writecommand(TFT_SLPOUT);
-	writecommand(TFT_NOP);
+	writecommand16(TFT_SLPOUT);
 	delay(100);
 
 	/* Display on */
-	writecommand(TFT_DISPON);
-	writecommand(TFT_NOP);
+	writecommand16(TFT_DISPON);
 	delay(50);
 
 	/* Memory Write */

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -5,16 +5,26 @@
 #define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
 #define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
 
-#ifndef TFT_CASET_CMD
-	#define TFT_CASET_CMD(x0, x1) \
-		DC_C; tft_Write_8(TFT_CASET); \
-		DC_D; tft_Write_32C(x0, x1)
+#define TFT_CASET_CMD(x0, x1) \
+  DC_C; tft_Write_16(TFT_CASET); \
+  DC_D; tft_Write_16(Byte8H(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 1); \
+  DC_D; tft_Write_16(Byte8L(x0)); \
+  DC_C; tft_Write_16(TFT_CASET + 2); \
+  DC_D; tft_Write_16(Byte8H(x1)); \
+  DC_C; tft_Write_16(TFT_CASET + 3); \
+  DC_D; tft_Write_16(Byte8L(x1))
 #endif
 
-#ifndef TFT_PASET_CMD
-	#define TFT_PASET_CMD(y0, y1) \
-		DC_C; tft_Write_8(TFT_PASET); \
-		DC_D; tft_Write_32C(y0, y1)
+#define TFT_PASET_CMD(y0, y1) \
+  DC_C; tft_Write_16(TFT_PASET); \
+  DC_D; tft_Write_16(Byte8H(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 1); \
+  DC_D; tft_Write_16(Byte8L(y0)); \
+  DC_C; tft_Write_16(TFT_PASET + 2); \
+  DC_D; tft_Write_16(Byte8H(y1)); \
+  DC_C; tft_Write_16(TFT_PASET + 3); \
+  DC_D; tft_Write_16(Byte8L(y1))
 #endif
 
 #define writecommand16(cmd) \

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -14,7 +14,6 @@
   DC_D; tft_Write_16(Byte8H(x1)); \
   DC_C; tft_Write_16(TFT_CASET + 3); \
   DC_D; tft_Write_16(Byte8L(x1))
-#endif
 
 #define TFT_PASET_CMD(y0, y1) \
   DC_C; tft_Write_16(TFT_PASET); \
@@ -25,7 +24,6 @@
   DC_D; tft_Write_16(Byte8H(y1)); \
   DC_C; tft_Write_16(TFT_PASET + 3); \
   DC_D; tft_Write_16(Byte8L(y1))
-#endif
 
 #define writecommand16(cmd) \
 	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -1,0 +1,416 @@
+
+// This is the command sequence that initialises the OTM8009A driver
+// Configure OTM8009A display
+
+#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
+#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
+
+#ifndef TFT_CASET_CMD
+	#define TFT_CASET_CMD(x0, x1) \
+		DC_C; tft_Write_8(TFT_CASET); \
+		DC_D; tft_Write_32C(x0, x1)
+#endif
+
+#ifndef TFT_PASET_CMD
+	#define TFT_PASET_CMD(y0, y1) \
+		DC_C; tft_Write_8(TFT_PASET); \
+		DC_D; tft_Write_32C(y0, y1)
+#endif
+
+#define writecommand16(cmd) \
+	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
+
+#define writedata16(data) \
+	writedata(Byte8H(data)); writedata(Byte8L(data))
+
+
+//3.97inch OTM8009 Init 20190116
+	/* Enter CMD2 */
+	writecommand16(MCS_CMD2_ENA1);
+	writedata16(0x80);
+	writecommand16(MCS_CMD2_ENA1 + 1);
+	writedata16(0x09);
+	writecommand16(MCS_CMD2_ENA1 + 2);
+	writedata16(0x01);
+	
+	/* Enter Orise Command2 */
+	writecommand16(MCS_CMD2_ENA2);
+	writedata16(0x80);
+	writecommand16(MCS_CMD2_ENA2 + 1);
+	writedata16(0x09);
+
+	/* Command not documented */
+	writecommand16(0xff03);
+	writedata16(0x01); //??
+
+	//add ==========20131216============================//
+	/* Command not documented */
+	writecommand16(0xf5b6); 
+	writedata16(0x06); //??
+
+	/* Source Driver Precharge Control */
+	writecommand16(MCS_SD_PCH_CTRL); 
+	writedata16(0x30); 
+	
+	/* Command not documented: 0xC48A */
+	writecommand16(MCS_NO_DOC1); 
+	writedata16(0x40); 
+	//===================================================//
+	
+	/* Source Driver Timing Setting */
+	writecommand16(MCS_SD_CTRL + 1);
+	writedata16(0x1B);
+
+	/* Command not documented */
+	writecommand16(0xc0ba); //--> (0xc0b4); // column inversion //  2013.12.16 modify
+	writedata16(0x50); 
+
+	/* Oscillator Adjustment for Idle/Normal mode */
+	writecommand16(MCS_OSC_ADJ);
+	writedata16(0x66); /* 65Hz */
+
+	/* RGB Video Mode Setting */
+	writecommand16(MCS_RGB_VID_SET);
+	writedata16(0x0E);
+
+	/* Source Driver Precharge Control */
+	writecommand16(MCS_SD_PCH_CTRL + 1);
+	writedata16(0x83);
+
+	/* Power Control Setting 1 */
+	writecommand16(MCS_PWR_CTRL1 + 2);
+	writedata16(0x83);
+
+	/* Power Control Setting 2 for Normal Mode */
+	writecommand16(MCS_PWR_CTRL2);
+	writedata16(0x96);
+
+	writecommand16(MCS_PWR_CTRL2 + 1);
+	writedata16(0x2B);
+
+	writecommand16(MCS_PWR_CTRL2 + 2);
+	writedata16(0x01);
+
+	writecommand16(MCS_PWR_CTRL2 + 4);
+	writedata16(0x33);
+
+	writecommand16(MCS_PWR_CTRL2 + 5);
+	writedata16(0x34);
+
+	/* Power Control Setting 4 for DC Voltage */
+	writecommand16(MCS_PWR_CTRL4 + 1);
+	writedata16(0xa9);
+
+	/* GOA VST Setting */
+	writecommand16(MCS_GOAVST);
+	writedata16(0x86);
+	writecommand16(MCS_GOAVST + 1);
+	writedata16(0x01); 
+	writecommand16(MCS_GOAVST + 2);
+	writedata16(0x00); 
+	writecommand16(MCS_GOAVST + 3);
+	writedata16(0x85); 
+	writecommand16(MCS_GOAVST + 4);
+	writedata16(0x01); 
+	writecommand16(MCS_GOAVST + 5);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 6);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 7);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 8);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 9);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 10);
+	writedata16(0x00);
+	writecommand16(MCS_GOAVST + 11);
+	writedata16(0x00);
+
+	/* GOA CLKA1 Setting */
+	writecommand16(MCS_GOACLKA1);// cea1[7:0] : clka1_width[3:0], clka1_shift[11:8]                         
+	writedata16(0x18); 
+	writecommand16(MCS_GOACLKA1 + 1);// cea2[7:0] : clka1_shift[7:0]                                            
+	writedata16(0x04); 
+	writecommand16(MCS_GOACLKA1 + 2);// cea3[7:0] : clka1_sw_tg, odd_high, flat_head, flat_tail, switch[11:8]   
+	writedata16(0x03); 
+	writecommand16(MCS_GOACLKA1 + 3);// cea4[7:0] : clka1_switch[7:0]                                               
+	writedata16(0x21); 
+	writecommand16(MCS_GOACLKA1 + 4);// cea5[7:0] : clka1_extend[7:0]                                           
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA1 + 5);// cea6[7:0] : clka1_tchop[7:0]                                            
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA1 + 6);// cea7[7:0] : clka1_tglue[7:0]                                            
+	writedata16(0x00); 
+
+	/* GOA CLKA2 Setting */
+	writecommand16(MCS_GOACLKA2);// cea8[7:0] : clka2_width[3:0], clka2_shift[11:8]                         
+	writedata16(0x18); 
+	writecommand16(MCS_GOACLKA2 + 1);// cea9[7:0] : clka2_shift[7:0]                                            
+	writedata16(0x03);
+	writecommand16(MCS_GOACLKA2 + 2);// ceaa[7:0] : clka2_sw_tg, odd_high, flat_head, flat_tail, switch[11:8]   
+	writedata16(0x03); 
+	writecommand16(MCS_GOACLKA2 + 3);// ceab[7:0] : clka2_switch[7:0]                                                
+	writedata16(0x22);
+	writecommand16(MCS_GOACLKA2 + 4);// ceac[7:0] : clka2_extend                                                
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA2 + 5);// cead[7:0] : clka2_tchop                                                 
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA2 + 6);// ceae[7:0] : clka2_tglue 
+	writedata16(0x00);    
+
+	/* GOA CLKA3 Setting */
+	writecommand16(MCS_GOACLKA3);// ceb1[7:0] : clka3_width[3:0], clka3_shift[11:8]                          
+	writedata16(0x18);
+	writecommand16(MCS_GOACLKA3 + 1);// ceb2[7:0] : clka3_shift[7:0]                                             
+	writedata16(0x02); 
+	writecommand16(MCS_GOACLKA3 + 2);// ceb3[7:0] : clka3_sw_tg, odd_high, flat_head, flat_tail, switch[11:8]    
+	writedata16(0x03); 
+	writecommand16(MCS_GOACLKA3 + 3);// ceb4[7:0] : clka3_switch[7:0]                                               
+	writedata16(0x23); 
+	writecommand16(MCS_GOACLKA3 + 4);// ceb5[7:0] : clka3_extend[7:0]                                            
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA3 + 5);// ceb6[7:0] : clka3_tchop[7:0]                                             
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA3 + 6);// ceb7[7:0] : clka3_tglue[7:0]                                             
+	writedata16(0x00); 
+	
+	/* GOA CLKA4 Setting */
+	writecommand16(MCS_GOACLKA4);// ceb8[7:0] : clka4_width[3:0], clka2_shift[11:8]                          
+	writedata16(0x18);
+	writecommand16(MCS_GOACLKA4 + 1);// ceb9[7:0] : clka4_shift[7:0]                                             
+	writedata16(0x01); 
+	writecommand16(MCS_GOACLKA4 + 2);// ceba[7:0] : clka4_sw_tg, odd_high, flat_head, flat_tail, switch[11:8]    
+	writedata16(0x03); 
+	writecommand16(MCS_GOACLKA4 + 3);// cebb[7:0] : clka4_switch[7:0]                                                
+	writedata16(0x24); 
+	writecommand16(MCS_GOACLKA4 + 4);// cebc[7:0] : clka4_extend                                                 
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA4 + 5);// cebd[7:0] : clka4_tchop                                                  
+	writedata16(0x00); 
+	writecommand16(MCS_GOACLKA4 + 6);// cebe[7:0] : clka4_tglue                                                  
+	writedata16(0x00); 
+
+	/* GOA ECLK Setting */
+	writecommand16(MCS_GOAECLK);// cfc1[7:0] : eclk_normal_width[7:0]   
+	writedata16(0x01); 
+	writecommand16(MCS_GOAECLK + 1);// cfc2[7:0] : eclk_partial_width[7:0]                                                                                  
+	writedata16(0x01); 
+	writecommand16(MCS_GOAECLK + 2);// cfc3[7:0] : all_normal_tchop[7:0]                                                                                    
+	writedata16(0x20); 
+	writecommand16(MCS_GOAECLK + 3);// cfc4[7:0] : all_partial_tchop[7:0]                                                                                   
+	writedata16(0x20); 
+	writecommand16(MCS_GOAECLK + 4);// cfc5[7:0] : eclk1_follow[3:0], eclk2_follow[3:0]                                                                     
+	writedata16(0x00); 
+	writecommand16(MCS_GOAECLK + 5);// cfc6[7:0] : eclk3_follow[3:0], eclk4_follow[3:0]                                                                     
+	writedata16(0x00); 
+	
+	/* GOA Other Options 1 */
+	writecommand16(MCS_GOAOPT1);// cfc7[7:0] : 00, vstmask, vendmask, 00, dir1, dir2 (0=VGL, 1=VGH)                                                     
+	writedata16(0x01); 
+
+	/* GOA Signal Toggle Option Setting */
+	writecommand16(MCS_GOATGOPT);// cfc8[7:0] : reg_goa_gnd_opt, reg_goa_dpgm_tail_set, reg_goa_f_gating_en, reg_goa_f_odd_gating, toggle_mod1, 2, 3, 4  
+	writedata16(0x00);    // GND OPT1 (00-->80  2011/10/28)	
+	writecommand16(MCS_GOATGOPT + 1);// cfc9[7:0] : duty_block[3:0], DGPM[3:0]                                                                               
+	writedata16(0x00); 
+	writecommand16(MCS_GOATGOPT + 2);// cfca[7:0] : reg_goa_gnd_period[7:0]                                                                                  
+	writedata16(0x00);    // Gate PCH (CLK base) (00-->0a  2011/10/28)
+
+	/* Command not documented: 0xCFD0 */
+	writecommand16(MCS_NO_DOC2);// cfd1[7:0] : 0000000, reg_goa_frame_odd_high
+	writedata16(0x00); 
+
+	/* Panel Control Setting 5 */
+	writecommand16(MCS_PANCTRLSET5);//cbc1[7:0] : enmode H-byte of sig1  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 1);//cbc2[7:0] : enmode H-byte of sig2  (pwrof_0, pwrof_1, norm, pwron_4 )          
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET5 + 2);//cbc3[7:0] : enmode H-byte of sig3  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET5 + 3);//cbc4[7:0] : enmode H-byte of sig4  (pwrof_0, pwrof_1, norm, pwron_4 )        
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET5 + 4);//cbc5[7:0] : enmode H-byte of sig5  (pwrof_0, pwrof_1, norm, pwron_4 )             
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET5 + 5);//cbc6[7:0] : enmode H-byte of sig6  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET5 + 6);//cbc7[7:0] : enmode H-byte of sig7  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 7);//cbc8[7:0] : enmode H-byte of sig8  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 8);//cbc9[7:0] : enmode H-byte of sig9  (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 9);//cbca[7:0] : enmode H-byte of sig10 (pwrof_0, pwrof_1, norm, pwron_4 )        
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 10);//cbcb[7:0] : enmode H-byte of sig11 (pwrof_0, pwrof_1, norm, pwron_4 )        
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 11);//cbcc[7:0] : enmode H-byte of sig12 (pwrof_0, pwrof_1, norm, pwron_4 )        
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 12);//cbcd[7:0] : enmode H-byte of sig13 (pwrof_0, pwrof_1, norm, pwron_4 )        
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 13);//cbce[7:0] : enmode H-byte of sig14 (pwrof_0, pwrof_1, norm, pwron_4 ) 
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET5 + 14);//cbcf[7:0] : enmode H-byte of sig15 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+
+	/* Panel Control Setting 6 */
+	writecommand16(MCS_PANCTRLSET6);//cbd1[7:0] : enmode H-byte of sig16 (pwrof_0, pwrof_1, norm, pwron_4 )           
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 1);//cbd2[7:0] : enmode H-byte of sig17 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 2);//cbd3[7:0] : enmode H-byte of sig18 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 3);//cbd4[7:0] : enmode H-byte of sig19 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 4);//cbd5[7:0] : enmode H-byte of sig20 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 5);//cbd6[7:0] : enmode H-byte of sig21 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 6);//cbd7[7:0] : enmode H-byte of sig22 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET6 + 7);//cbd8[7:0] : enmode H-byte of sig23 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET6 + 8);//cbd9[7:0] : enmode H-byte of sig24 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET6 + 9);//cbda[7:0] : enmode H-byte of sig25 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET6 + 10);//cbdb[7:0] : enmode H-byte of sig26 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x04); 
+	writecommand16(MCS_PANCTRLSET6 + 11);//cbdc[7:0] : enmode H-byte of sig27 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 12);//cbdd[7:0] : enmode H-byte of sig28 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 13);//cbde[7:0] : enmode H-byte of sig29 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET6 + 14);//cbdf[7:0] : enmode H-byte of sig30 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+
+	/* Panel Control Setting 7 */
+	writecommand16(MCS_PANCTRLSET7);//cbe1[7:0] : enmode H-byte of sig31 (pwrof_0, pwrof_1, norm, pwron_4 )             
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 1);//cbe2[7:0] : enmode H-byte of sig32 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 2);//cbe3[7:0] : enmode H-byte of sig33 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 3);//cbe4[7:0] : enmode H-byte of sig34 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 4);//cbe5[7:0] : enmode H-byte of sig35 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 5);//cbe6[7:0] : enmode H-byte of sig36 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 6);//cbe7[7:0] : enmode H-byte of sig37 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 7);//cbe8[7:0] : enmode H-byte of sig38 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 8);//cbe9[7:0] : enmode H-byte of sig39 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00); 
+	writecommand16(MCS_PANCTRLSET7 + 9);//cbea[7:0] : enmode H-byte of sig40 (pwrof_0, pwrof_1, norm, pwron_4 )
+	writedata16(0x00);
+	
+	/* Panel U2D Setting 1 */  
+	// cc8x 
+	writecommand16(MCS_PANU2D1);//cc81[7:0] : reg setting for signal01 selection with u2d mode   
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D1 + 1);//cc82[7:0] : reg setting for signal02 selection with u2d mode 
+	writedata16(0x26); 
+	writecommand16(MCS_PANU2D1 + 2);//cc83[7:0] : reg setting for signal03 selection with u2d mode 
+	writedata16(0x09); 
+	writecommand16(MCS_PANU2D1 + 3);//cc84[7:0] : reg setting for signal04 selection with u2d mode 
+	writedata16(0x0B); 
+	writecommand16(MCS_PANU2D1 + 4);//cc85[7:0] : reg setting for signal05 selection with u2d mode 
+	writedata16(0x01); 
+	writecommand16(MCS_PANU2D1 + 5);//cc86[7:0] : reg setting for signal06 selection with u2d mode 
+	writedata16(0x25); 
+	writecommand16(MCS_PANU2D1 + 6);//cc87[7:0] : reg setting for signal07 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D1 + 7);//cc88[7:0] : reg setting for signal08 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D1 + 8);//cc89[7:0] : reg setting for signal09 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D1 + 9);//cc8a[7:0] : reg setting for signal10 selection with u2d mode 
+	writedata16(0x00);  
+
+	/* Panel U2D Setting 2 */
+	// cc9x   
+	writecommand16(MCS_PANU2D2);//cc91[7:0] : reg setting for signal11 selection with u2d mode   
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 1);//cc92[7:0] : reg setting for signal12 selection with u2d mode
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 2);//cc93[7:0] : reg setting for signal13 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 3);//cc94[7:0] : reg setting for signal14 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 4);//cc95[7:0] : reg setting for signal15 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 5);//cc96[7:0] : reg setting for signal16 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 6);//cc97[7:0] : reg setting for signal17 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 7);//cc98[7:0] : reg setting for signal18 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 8);//cc99[7:0] : reg setting for signal19 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 9);//cc9a[7:0] : reg setting for signal20 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 10);//cc9b[7:0] : reg setting for signal21 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D2 + 11);//cc9c[7:0] : reg setting for signal22 selection with u2d mode 
+	writedata16(0x26); 
+	writecommand16(MCS_PANU2D2 + 12);//cc9d[7:0] : reg setting for signal23 selection with u2d mode 
+	writedata16(0x0A); 
+	writecommand16(MCS_PANU2D2 + 13);//cc9e[7:0] : reg setting for signal24 selection with u2d mode 
+	writedata16(0x0C); 
+	writecommand16(MCS_PANU2D2 + 14);//cc9f[7:0] : reg setting for signal25 selection with u2d mode 
+	writedata16(0x02);  		
+	
+	/* Panel U2D Setting 3 */
+	// ccax   
+	writecommand16(MCS_PANU2D3);//cca1[7:0] : reg setting for signal26 selection with u2d mode   
+	writedata16(0x25); 
+	writecommand16(MCS_PANU2D3 + 1);//cca2[7:0] : reg setting for signal27 selection with u2d mode
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 2);//cca3[7:0] : reg setting for signal28 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 3);//cca4[7:0] : reg setting for signal29 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 4);//cca5[7:0] : reg setting for signal20 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 5);//cca6[7:0] : reg setting for signal31 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 6);//cca7[7:0] : reg setting for signal32 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 7);//cca8[7:0] : reg setting for signal33 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 8);//cca9[7:0] : reg setting for signal34 selection with u2d mode 
+	writedata16(0x00); 
+	writecommand16(MCS_PANU2D3 + 9);//ccaa[7:0] : reg setting for signal35 selection with u2d mode 
+	writedata16(0x00); 
+
+  	/* Command not documented: 0x3A00 */
+	writecommand16(0x3A00);//ccaa[7:0] : reg setting for signal35 selection with u2d mode 
+	writedata16(0x55);//0x55
+		
+	
+	
+	// /* Exit CMD2 - new! */
+	// writecommand16(MCS_CMD2_ENA1);
+	// writedata16(0xFF);
+	// writecommand16(MCS_CMD2_ENA1 + 1);
+	// writedata16(0xFF);
+	// writecommand16(MCS_CMD2_ENA1 + 2);
+	// writedata16(0xFF);
+	
+	
+	/* Sleep out */
+	writecommand(TFT_SLPOUT);
+	writecommand(TFT_NOP);
+	delay(100);
+
+	/* Display on */
+	writecommand(TFT_DISPON);
+	writecommand(TFT_NOP);
+	delay(50);
+
+	/* Memory Write */
+	//writecommand16(0x2C00); 
+// End of OTM8009A display configuration

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -367,21 +367,22 @@
 	writecommand16(0x3A00);//ccaa[7:0] : reg setting for signal35 selection with u2d mode 
 	writedata16(0x55);//0x55
 			
-	// /* Exit CMD2 - new! */
-	// writecommand16(MCS_CMD2_ENA1);
-	// writedata16(0xFF);
-	// writecommand16(MCS_CMD2_ENA1 + 1);
-	// writedata16(0xFF);
-	// writecommand16(MCS_CMD2_ENA1 + 2);
-	// writedata16(0xFF);
-	
+	/* Exit CMD2 - new! */
+	writecommand16(MCS_CMD2_ENA1);
+	writedata16(0xFF);
+	writecommand16(MCS_CMD2_ENA1 + 1);
+	writedata16(0xFF);
+	writecommand16(MCS_CMD2_ENA1 + 2);
+	writedata16(0xFF);
 	
 	/* Sleep out */
-	writecommand16(TFT_SLPOUT);
+	writecommand(TFT_SLPOUT);
+	writecommand(TFT_NOP);
 	delay(100);
 
 	/* Display on */
-	writecommand16(TFT_DISPON);
+	writecommand(TFT_DISPON);
+	writecommand(TFT_NOP);
 	delay(50);
 
 	/* Memory Write */

--- a/TFT_Drivers/OTM8009A_Init.h
+++ b/TFT_Drivers/OTM8009A_Init.h
@@ -1,36 +1,5 @@
-
 // This is the command sequence that initialises the OTM8009A driver
 // Configure OTM8009A display
-
-#define Byte8H(ByteH) ((uint8_t)(((uint16_t)(ByteH)&0xFF00)>>8))
-#define Byte8L(ByteL) ((uint8_t)( (uint16_t)(ByteL)&0x00FF))
-
-#define TFT_CASET_CMD(x0, x1) \
-  DC_C; tft_Write_16(TFT_CASET); \
-  DC_D; tft_Write_16(Byte8H(x0)); \
-  DC_C; tft_Write_16(TFT_CASET + 1); \
-  DC_D; tft_Write_16(Byte8L(x0)); \
-  DC_C; tft_Write_16(TFT_CASET + 2); \
-  DC_D; tft_Write_16(Byte8H(x1)); \
-  DC_C; tft_Write_16(TFT_CASET + 3); \
-  DC_D; tft_Write_16(Byte8L(x1))
-
-#define TFT_PASET_CMD(y0, y1) \
-  DC_C; tft_Write_16(TFT_PASET); \
-  DC_D; tft_Write_16(Byte8H(y0)); \
-  DC_C; tft_Write_16(TFT_PASET + 1); \
-  DC_D; tft_Write_16(Byte8L(y0)); \
-  DC_C; tft_Write_16(TFT_PASET + 2); \
-  DC_D; tft_Write_16(Byte8H(y1)); \
-  DC_C; tft_Write_16(TFT_PASET + 3); \
-  DC_D; tft_Write_16(Byte8L(y1))
-
-#define writecommand16(cmd) \
-	writecommand(Byte8H(cmd)); writecommand(Byte8L(cmd))
-
-#define writedata16(data) \
-	writedata(Byte8H(data)); writedata(Byte8L(data))
-
 
 //3.97inch OTM8009 Init 20190116
 	/* Enter CMD2 */
@@ -397,9 +366,7 @@
   	/* Command not documented: 0x3A00 */
 	writecommand16(0x3A00);//ccaa[7:0] : reg setting for signal35 selection with u2d mode 
 	writedata16(0x55);//0x55
-		
-	
-	
+			
 	// /* Exit CMD2 - new! */
 	// writecommand16(MCS_CMD2_ENA1);
 	// writedata16(0xFF);
@@ -410,15 +377,13 @@
 	
 	
 	/* Sleep out */
-	writecommand(TFT_SLPOUT);
-	writecommand(TFT_NOP);
+	writecommand16(TFT_SLPOUT);
 	delay(100);
 
 	/* Display on */
-	writecommand(TFT_DISPON);
-	writecommand(TFT_NOP);
+	writecommand16(TFT_DISPON);
 	delay(50);
 
 	/* Memory Write */
-	//writecommand16(0x2C00); 
+	//writecommand16(TFT_RAMWR); 
 // End of OTM8009A display configuration

--- a/TFT_Drivers/OTM8009A_Rotation.h
+++ b/TFT_Drivers/OTM8009A_Rotation.h
@@ -1,25 +1,25 @@
   // This is the command sequence that rotates the OTM8009A driver coordinate frame
   rotation = m % 4;
-  writecommand16(TFT_MADCTL);
+  writecommand(TFT_MADCTL);
 
   switch (rotation) {
    case 0: // Portrait
-      writedata16(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
+      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_WIDTH;
       _height = TFT_HEIGHT;      
      break;
    case 1: // Landscape (Portrait + 90)
-      writedata16(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
+      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;      
      break;
    case 2: // Inverter portrait
-      writedata16(TFT_MAD_RGB);
+      writedata(TFT_MAD_RGB);
       _width  = TFT_WIDTH;
       _height = TFT_HEIGHT;      
      break;
    case 3: // Inverted landscape
-      writedata16(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
+      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
      break;

--- a/TFT_Drivers/OTM8009A_Rotation.h
+++ b/TFT_Drivers/OTM8009A_Rotation.h
@@ -1,32 +1,26 @@
   // This is the command sequence that rotates the OTM8009A driver coordinate frame
-
   rotation = m % 4;
-  writecommand(TFT_MADCTL);
-  writecommand(TFT_NOP);
+  writecommand16(TFT_MADCTL);
+
   switch (rotation) {
    case 0: // Portrait
+      writedata16(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-      writedata(0x00);
-      writedata(0x00);
+      _height = TFT_HEIGHT;      
      break;
    case 1: // Landscape (Portrait + 90)
+      writedata16(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
-      _height = TFT_WIDTH;
-      writedata((1<<5)|(1<<6));
-      writedata(0x00);
+      _height = TFT_WIDTH;      
      break;
    case 2: // Inverter portrait
+      writedata16(TFT_MAD_RGB);
       _width  = TFT_WIDTH;
-      _height = TFT_HEIGHT;
-      writedata((1<<7)|(1<<6));
-      writedata(0x00);
+      _height = TFT_HEIGHT;      
      break;
    case 3: // Inverted landscape
+      writedata16(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
-      
-      writedata((1<<7)|(1<<5));
-      writedata(0x00);
      break;
   }

--- a/TFT_Drivers/OTM8009A_Rotation.h
+++ b/TFT_Drivers/OTM8009A_Rotation.h
@@ -1,25 +1,25 @@
   // This is the command sequence that rotates the OTM8009A driver coordinate frame
   rotation = m % 4;
-  writecommand(TFT_MADCTL);
+  writecommand16(TFT_MADCTL);
 
   switch (rotation) {
    case 0: // Portrait
-      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
+      writedata16(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_WIDTH;
       _height = TFT_HEIGHT;      
      break;
    case 1: // Landscape (Portrait + 90)
-      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
+      writedata16(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;      
      break;
    case 2: // Inverter portrait
-      writedata(TFT_MAD_RGB);
+      writedata16(TFT_MAD_RGB);
       _width  = TFT_WIDTH;
       _height = TFT_HEIGHT;      
      break;
    case 3: // Inverted landscape
-      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
+      writedata16(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
      break;

--- a/TFT_Drivers/OTM8009A_Rotation.h
+++ b/TFT_Drivers/OTM8009A_Rotation.h
@@ -1,0 +1,32 @@
+  // This is the command sequence that rotates the OTM8009A driver coordinate frame
+
+  rotation = m % 4;
+  writecommand(TFT_MADCTL);
+  writecommand(TFT_NOP);
+  switch (rotation) {
+   case 0: // Portrait
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      writedata(0x00);
+      writedata(0x00);
+     break;
+   case 1: // Landscape (Portrait + 90)
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      writedata((1<<5)|(1<<6));
+      writedata(0x00);
+     break;
+   case 2: // Inverter portrait
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+      writedata((1<<7)|(1<<6));
+      writedata(0x00);
+     break;
+   case 3: // Inverted landscape
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+      
+      writedata((1<<7)|(1<<5));
+      writedata(0x00);
+     break;
+  }

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -399,6 +399,12 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Init.h"
 
+#elif defined (OTM8009A_DRIVER)
+    #include "TFT_Drivers/OTM8009A_Init.h"
+
+#elif defined (NT35510_DRIVER)
+    #include "TFT_Drivers/NT35510_Init.h"
+	
 #endif
 
 #ifdef TFT_INVERSION_ON
@@ -474,6 +480,12 @@ void TFT_eSPI::setRotation(uint8_t m)
 
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Rotation.h"
+
+#elif defined (OTM8009A_DRIVER)
+    #include "TFT_Drivers/OTM8009A_Rotation.h"
+
+#elif defined (NT35510_DRIVER)
+    #include "TFT_Drivers/NT35510_Rotation.h"
 
 #endif
 

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -399,12 +399,6 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Init.h"
 
-#elif defined (OTM8009A_DRIVER)
-    #include "TFT_Drivers/OTM8009A_Init.h"
-
-#elif defined (NT35510_DRIVER)
-    #include "TFT_Drivers/NT35510_Init.h"
-	
 #endif
 
 #ifdef TFT_INVERSION_ON
@@ -481,12 +475,6 @@ void TFT_eSPI::setRotation(uint8_t m)
 #elif defined (ST7789_2_DRIVER)
     #include "TFT_Drivers/ST7789_2_Rotation.h"
 
-#elif defined (OTM8009A_DRIVER)
-    #include "TFT_Drivers/OTM8009A_Rotation.h"
-
-#elif defined (NT35510_DRIVER)
-    #include "TFT_Drivers/NT35510_Rotation.h"
-
 #endif
 
   delayMicroseconds(10);
@@ -497,17 +485,6 @@ void TFT_eSPI::setRotation(uint8_t m)
   addr_col = 0xFFFF;
 }
 
-#ifndef TFT_CASET_CMD
-	#define TFT_CASET_CMD(x0, x1) \
-		DC_C; tft_Write_8(TFT_CASET); \
-		DC_D; tft_Write_32C(x0, x1)
-#endif
-
-#ifndef TFT_PASET_CMD
-	#define TFT_PASET_CMD(y0, y1) \
-		DC_C; tft_Write_8(TFT_PASET); \
-		DC_D; tft_Write_32C(y0, y1)
-#endif
 
 /***************************************************************************************
 ** Function name:           commandList, used for FLASH based lists only (e.g. ST7735)
@@ -2646,18 +2623,22 @@ void TFT_eSPI::setWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
 
 #ifdef MULTI_TFT_SUPPORT
   // No optimisation to permit multiple screens
-  TFT_CASET_CMD(x0, x1);
-  TFT_PASET_CMD(y0, y1);
+  DC_C; tft_Write_8(TFT_CASET);
+  DC_D; tft_Write_32C(x0, x1);
+  DC_C; tft_Write_8(TFT_PASET);
+  DC_D; tft_Write_32C(y0, y1);
 #else
   // No need to send x if it has not changed (speeds things up)
   if (addr_col != (x0<<16 | x1)) {
-    TFT_CASET_CMD(x0, x1);
+    DC_C; tft_Write_8(TFT_CASET);
+    DC_D; tft_Write_32C(x0, x1);
     addr_col = (x0<<16 | x1);
   }
 
   // No need to send y if it has not changed (speeds things up)
   if (addr_row != (y0<<16 | y1)) {
-    TFT_PASET_CMD(y0, y1);
+    DC_C; tft_Write_8(TFT_PASET);
+    DC_D; tft_Write_32C(y0, y1);
     addr_row = (y0<<16 | y1);
   }
 #endif
@@ -2691,10 +2672,12 @@ void TFT_eSPI::readAddrWindow(int32_t xs, int32_t ys, int32_t w, int32_t h)
 #endif
 
   // Column addr set
-  TFT_CASET_CMD(xs, xe);
+  DC_C; tft_Write_8(TFT_CASET);
+  DC_D; tft_Write_32C(xs, xe);
 
   // Row addr set
-  TFT_PASET_CMD(ys, ye);
+  DC_C; tft_Write_8(TFT_PASET);
+  DC_D; tft_Write_32C(ys, ye);
 
   // Read CGRAM command
   DC_C; tft_Write_8(TFT_RAMRD);
@@ -2723,18 +2706,22 @@ void TFT_eSPI::drawPixel(int32_t x, int32_t y, uint32_t color)
 
 #ifdef MULTI_TFT_SUPPORT
   // No optimisation
-  TFT_CASET_CMD(x, x);
-  TFT_PASET_CMD(y, y);
+  DC_C; tft_Write_8(TFT_CASET);
+  DC_D; tft_Write_32D(x);
+  DC_C; tft_Write_8(TFT_PASET);
+  DC_D; tft_Write_32D(y);
 #else
   // No need to send x if it has not changed (speeds things up)
   if (addr_col != (x<<16 | x)) {
-    TFT_CASET_CMD(x, x);
+    DC_C; tft_Write_8(TFT_CASET);
+    DC_D; tft_Write_32D(x);
     addr_col = (x<<16 | x);
   }
 
   // No need to send y if it has not changed (speeds things up)
   if (addr_row != (y<<16 | y)) {
-    TFT_PASET_CMD(y, y);
+    DC_C; tft_Write_8(TFT_PASET);
+    DC_D; tft_Write_32D(y);
     addr_row = (y<<16 | y);
   }
 #endif
@@ -4300,4 +4287,3 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
-

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -497,6 +497,17 @@ void TFT_eSPI::setRotation(uint8_t m)
   addr_col = 0xFFFF;
 }
 
+#ifndef TFT_CASET_CMD
+	#define TFT_CASET_CMD(x0, x1) \
+		DC_C; tft_Write_8(TFT_CASET); \
+		DC_D; tft_Write_32C(x0, x1)
+#endif
+
+#ifndef TFT_PASET_CMD
+	#define TFT_PASET_CMD(y0, y1) \
+		DC_C; tft_Write_8(TFT_PASET); \
+		DC_D; tft_Write_32C(y0, y1)
+#endif
 
 /***************************************************************************************
 ** Function name:           commandList, used for FLASH based lists only (e.g. ST7735)
@@ -2635,22 +2646,18 @@ void TFT_eSPI::setWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
 
 #ifdef MULTI_TFT_SUPPORT
   // No optimisation to permit multiple screens
-  DC_C; tft_Write_8(TFT_CASET);
-  DC_D; tft_Write_32C(x0, x1);
-  DC_C; tft_Write_8(TFT_PASET);
-  DC_D; tft_Write_32C(y0, y1);
+  TFT_CASET_CMD(x0, x1);
+  TFT_PASET_CMD(y0, y1);
 #else
   // No need to send x if it has not changed (speeds things up)
   if (addr_col != (x0<<16 | x1)) {
-    DC_C; tft_Write_8(TFT_CASET);
-    DC_D; tft_Write_32C(x0, x1);
+    TFT_CASET_CMD(x0, x1);
     addr_col = (x0<<16 | x1);
   }
 
   // No need to send y if it has not changed (speeds things up)
   if (addr_row != (y0<<16 | y1)) {
-    DC_C; tft_Write_8(TFT_PASET);
-    DC_D; tft_Write_32C(y0, y1);
+    TFT_PASET_CMD(y0, y1);
     addr_row = (y0<<16 | y1);
   }
 #endif
@@ -2684,12 +2691,10 @@ void TFT_eSPI::readAddrWindow(int32_t xs, int32_t ys, int32_t w, int32_t h)
 #endif
 
   // Column addr set
-  DC_C; tft_Write_8(TFT_CASET);
-  DC_D; tft_Write_32C(xs, xe);
+  TFT_CASET_CMD(xs, xe);
 
   // Row addr set
-  DC_C; tft_Write_8(TFT_PASET);
-  DC_D; tft_Write_32C(ys, ye);
+  TFT_PASET_CMD(ys, ye);
 
   // Read CGRAM command
   DC_C; tft_Write_8(TFT_RAMRD);
@@ -2718,22 +2723,18 @@ void TFT_eSPI::drawPixel(int32_t x, int32_t y, uint32_t color)
 
 #ifdef MULTI_TFT_SUPPORT
   // No optimisation
-  DC_C; tft_Write_8(TFT_CASET);
-  DC_D; tft_Write_32D(x);
-  DC_C; tft_Write_8(TFT_PASET);
-  DC_D; tft_Write_32D(y);
+  TFT_CASET_CMD(x, x);
+  TFT_PASET_CMD(y, y);
 #else
   // No need to send x if it has not changed (speeds things up)
   if (addr_col != (x<<16 | x)) {
-    DC_C; tft_Write_8(TFT_CASET);
-    DC_D; tft_Write_32D(x);
+    TFT_CASET_CMD(x, x);
     addr_col = (x<<16 | x);
   }
 
   // No need to send y if it has not changed (speeds things up)
   if (addr_row != (y<<16 | y)) {
-    DC_C; tft_Write_8(TFT_PASET);
-    DC_D; tft_Write_32D(y);
+    TFT_PASET_CMD(y, y);
     addr_row = (y<<16 | y);
   }
 #endif

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -154,6 +154,12 @@
 #elif defined (RM68140_DRIVER)
      #include "TFT_Drivers/RM68140_Defines.h"
      #define  TFT_DRIVER 0x6814
+#elif defined (OTM8009A_DRIVER)
+     #include "TFT_Drivers/OTM8009A_Defines.h"
+     #define  TFT_DRIVER 0x8009
+#elif defined (NT35510_DRIVER)
+     #include "TFT_Drivers/NT35510_Defines.h"
+     #define  TFT_DRIVER 0x3551	 
                               // <<<<<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVER HERE
                               // XYZZY_init.h and XYZZY_rotation.h must also be added in TFT_eSPI.c
 #elif defined (XYZZY_DRIVER)


### PR DESCRIPTION
I'm trying to use this library with Nucleo-144 STM32F746ZG board, but it fail immediately with message:

In file included from C:\Users\Stefano\Downloads\TEST\Graph_2\Graph_2.ino:14:
C:\Users\Stefano\Downloads\TEST\Graph_2/TFT_eSPI.h:16: error: unterminated #ifndef
   16 | #ifndef _TFT_eSPIH_
      | 
exit status 1
Error compiling for board Nucleo-144.

On the "user_setup.h" file i have only uncommented the following settings:
#define STM32
#define TFT_PARALLEL_8_BIT
#define OTM8009_DRIVER
#define TFT_CS   PD7
#define TFT_DC   PD13
#define TFT_RST  PD6
#define TFT_WR   PD5
#define TFT_RD   PD4
#define TFT_D0   PD14
#define TFT_D1   PD15
#define TFT_D2   PD0
#define TFT_D3   PD1
#define TFT_D4   PE7
#define TFT_D5   PE8
#define TFT_D6   PE9
#define TFT_D7   PE10

The line saying "//#define NUCLEO_144_TFT" commented or uncommented, give the same error.
My environment compile or this board without any errors other projects and other libraries (like "GxTFT" that i've used to try out this kind of display and it works natively in 16bit mode, but is not so fast as you library tested with other display).