### PR TITLE
Prevent TFT_eSprite::pushToSprite() to skips pixels when dealing with…

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -785,7 +785,7 @@ bool TFT_eSprite::pushToSprite(TFT_eSprite *dspr, int32_t x, int32_t y, uint16_t
           ox += pixel_count;
           pixel_count = 0;
         }
-        else ox++;
+        ox++;
       }
       else {
         sline_buffer[pixel_count++] = rp;


### PR DESCRIPTION
… transparency.

The ox counter is incorrectly incremented in TFT_eSprite::pushToSprite(), which create issues with sprites containing transparency.
For example, if you create two full screen sized sprites, and draw the same grid on both of them with a different color, and use pushToSprite with transparency to push one of them on top of the other, you'd expect the two grid to superpose perfectly, but instead you get this:

![Incorrect](https://user-images.githubusercontent.com/144694/152624304-e097bccf-7a7f-4bcb-8f9a-91447b8bf39f.jpg)

The top grid is the blue one, and it seems to skip one pixel every time a transparent area is crossed.

The PR fixes this problem.
