### PR TITLE
Support esp32 - c3

### DIFF
--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -277,6 +277,11 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
     while (*_spi_cmd&SPI_USR);
     for (i=0; i < rem; i+=2) *spi_w++ = color32;
     *_spi_mosi_dlen = (rem << 4) - 1;
+#if CONFIG_IDF_TARGET_ESP32C3
+    *_spi_cmd = SPI_UPDATE;
+    while (*_spi_cmd & SPI_UPDATE)
+      ;
+#endif
     *_spi_cmd = SPI_USR;
     if (!len) return; //{while (*_spi_cmd&SPI_USR); return; }
     i = i>>1; while(i++<16) *spi_w++ = color32;
@@ -289,6 +294,11 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
   // End with full buffer to maximise useful time for downstream code
   while(len)
   {
+#if CONFIG_IDF_TARGET_ESP32C3
+    *_spi_cmd = SPI_UPDATE;
+    while (*_spi_cmd & SPI_UPDATE)
+      ;
+#endif
     while (*_spi_cmd&SPI_USR);
     *_spi_cmd = SPI_USR;
     len -= 32;
@@ -335,6 +345,11 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
       WRITE_PERI_REG(SPI_W13_REG(SPI_PORT), color[13]);
       WRITE_PERI_REG(SPI_W14_REG(SPI_PORT), color[14]);
       WRITE_PERI_REG(SPI_W15_REG(SPI_PORT), color[15]);
+      #if CONFIG_IDF_TARGET_ESP32C3
+        SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_UPDATE);
+        while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_UPDATE)
+            ;
+      #endif
       SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_USR);
       len -= 32;
     }
@@ -358,6 +373,11 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
     WRITE_PERI_REG(SPI_W5_REG(SPI_PORT),  color[5]);
     WRITE_PERI_REG(SPI_W6_REG(SPI_PORT),  color[6]);
     WRITE_PERI_REG(SPI_W7_REG(SPI_PORT),  color[7]);
+    #if CONFIG_IDF_TARGET_ESP32C3
+        SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_UPDATE);
+        while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_UPDATE)
+            ;
+    #endif
     SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_USR);
     len -= 16;
   }
@@ -369,6 +389,11 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
     for (uint32_t i=0; i <= (len<<1); i+=4) {
       WRITE_PERI_REG(SPI_W0_REG(SPI_PORT)+i, DAT8TO32(data)); data+=4;
     }
+    #if CONFIG_IDF_TARGET_ESP32C3
+        SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_UPDATE);
+        while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_UPDATE)
+            ;
+    #endif
     SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_USR);
   }
   while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
@@ -410,6 +435,11 @@ void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
       WRITE_PERI_REG(SPI_W13_REG(SPI_PORT), *data++);
       WRITE_PERI_REG(SPI_W14_REG(SPI_PORT), *data++);
       WRITE_PERI_REG(SPI_W15_REG(SPI_PORT), *data++);
+      #if CONFIG_IDF_TARGET_ESP32C3
+        SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_UPDATE);
+        while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_UPDATE)
+            ;
+      #endif
       SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_USR);
       len -= 32;
     }
@@ -420,6 +450,11 @@ void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
     while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);
     WRITE_PERI_REG(SPI_MOSI_DLEN_REG(SPI_PORT), (len << 4) - 1);
     for (uint32_t i=0; i <= (len<<1); i+=4) WRITE_PERI_REG((SPI_W0_REG(SPI_PORT) + i), *data++);
+    #if CONFIG_IDF_TARGET_ESP32C3
+        SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_UPDATE);
+        while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_UPDATE)
+            ;
+    #endif
     SET_PERI_REG_MASK(SPI_CMD_REG(SPI_PORT), SPI_USR);
   }
   while (READ_PERI_REG(SPI_CMD_REG(SPI_PORT))&SPI_USR);

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -20,7 +20,7 @@
 #if CONFIG_IDF_TARGET_ESP32C3
   // Fix ESP32C3 IDF bug for missing definition
   #ifndef REG_SPI_BASE
-    #define REG_SPI_BASE(i)     (DR_REG_SPI1_BASE + (((i)>1) ? (((i)* 0x1000) + 0x20000) : (((~(i)) & 1)* 0x1000 )))
+    #define REG_SPI_BASE(i)   DR_REG_SPI2_BASE
   #endif
 
   // Fix ESP32C3 IDF bug for name change
@@ -76,8 +76,10 @@ SPI3_HOST = 2
 #else
   #ifdef CONFIG_IDF_TARGET_ESP32
     #define SPI_PORT VSPI
-  #else
+  #elif CONFIG_IDF_TARGET_ESP32S2
     #define SPI_PORT 2 //FSPI(ESP32 S2)
+  #elif CONFIG_IDF_TARGET_ESP32C3
+    #define SPI_PORT FSPI //FSPI(ESP32 c3)
   #endif
 #endif
 
@@ -535,7 +537,9 @@ SPI3_HOST = 2
 //* Replacement slimmer macros
   #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;    \
                                *_spi_w = D;             \
-                               *_spi_cmd = SPI_USR;      \
+                               *_spi_cmd = SPI_UPDATE;      \
+                        while (*_spi_cmd & SPI_UPDATE);    \                                  
+                               *_spi_cmd = SPI_USR;    \
                         while (*_spi_cmd & SPI_USR);
 
   // Write 8 bits
@@ -547,7 +551,11 @@ SPI3_HOST = 2
   // Future option for transfer without wait
   #define tft_Write_16N(C) *_spi_mosi_dlen = 16-1;       \
                            *_spi_w = ((C)<<8 | (C)>>8); \
-                           *_spi_cmd = SPI_USR;
+                           *_spi_cmd = SPI_UPDATE;       \
+                        while (*_spi_cmd & SPI_UPDATE); \
+                           *_spi_cmd = SPI_USR;    \ 
+                        while (*_spi_cmd & SPI_USR);
+
 
   // Write 16 bits
   #define tft_Write_16S(C) TFT_WRITE_BITS(C, 16)


### PR DESCRIPTION
1.esp32-c3 has only one spi that can be configured in general mode
2.Check the arduino library source code of esp32 (esp32-hal-spi.c), the spi processing method of c3 is slightly different, but I did not find the documentation