### PR TITLE
add ST7789 240X280 1.69inch TFT Setup file

### DIFF
--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -10,6 +10,11 @@
         colstart = 52;
         rowstart = 40;
       }
+      else if(_init_height == 280)
+      {
+        colstart = 0;
+        rowstart = 20;
+      }
       else
       {
         colstart = 0;
@@ -28,6 +33,11 @@
       {
         colstart = 40;
         rowstart = 53;
+      }
+      else if(_init_height == 280)
+      {
+        colstart = 20;
+        rowstart = 0;
       }
       else
       {
@@ -48,6 +58,11 @@
         colstart = 53;
         rowstart = 40;
       }
+      else if(_init_height == 280)
+      {
+        colstart = 0;
+        rowstart = 20;
+      }
       else
       {
         colstart = 0;
@@ -65,6 +80,11 @@
       {
         colstart = 40;
         rowstart = 52;
+      }
+      else if(_init_height == 280)
+      {
+        colstart = 20;
+        rowstart = 0;
       }
       else
       {

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -105,6 +105,8 @@
 
 //#include <User_Setups/Setup202_SSD1351_128.h>      // Setup file for ESP32/ESP8266 based SSD1351 128x128 1.5inch OLED display
 
+#include <User_Setups/Setup202_ST7789.h>     // Setup file for ESP32/ESP8266 based ST7789 240X280 1.69inch TFT 
+
 //#include <User_Setups/SetupX_Template.h>
 
 

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -105,7 +105,7 @@
 
 //#include <User_Setups/Setup202_SSD1351_128.h>      // Setup file for ESP32/ESP8266 based SSD1351 128x128 1.5inch OLED display
 
-#include <User_Setups/Setup202_ST7789.h>     // Setup file for ESP32/ESP8266 based ST7789 240X280 1.69inch TFT 
+//#include <User_Setups/Setup203_ST7789.h>     // Setup file for ESP32/ESP8266 based ST7789 240X280 1.69inch TFT 
 
 //#include <User_Setups/SetupX_Template.h>
 

--- a/User_Setups/Setup202_ST7789.h
+++ b/User_Setups/Setup202_ST7789.h
@@ -1,0 +1,56 @@
+// ST7789 240 x 280 display with no chip select line
+
+#define ST7789_DRIVER     // Configure all registers
+
+#define TFT_WIDTH  240
+#define TFT_HEIGHT 280
+
+#define CGRAM_OFFSET      // Library will add offsets required
+
+//#define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+//#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
+//#define TFT_INVERSION_ON
+//#define TFT_INVERSION_OFF
+
+// DSTIKE stepup
+//#define TFT_DC    23
+//#define TFT_RST   32
+//#define TFT_MOSI  26
+//#define TFT_SCLK  27
+
+// Generic ESP32 setup
+//#define TFT_MISO 19
+//#define TFT_MOSI 23
+//#define TFT_SCLK 18
+//#define TFT_CS    -1 // Not connected
+//#define TFT_DC    2
+//#define TFT_RST   4  // Connect reset to ensure display initialises
+
+// For NodeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
+#define TFT_CS   -1      // Define as not used
+#define TFT_DC   PIN_D1  // Data Command control pin
+//#define TFT_RST  PIN_D4  // TFT reset pin (could connect to NodeMCU RST, see next line)
+#define TFT_RST  -1      // TFT reset pin connect to NodeMCU RST, must also then add 10K pull down to TFT SCK
+
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+
+// #define SPI_FREQUENCY  27000000
+#define SPI_FREQUENCY  40000000
+
+#define SPI_READ_FREQUENCY  20000000
+
+#define SPI_TOUCH_FREQUENCY  2500000
+
+// #define SUPPORT_TRANSACTIONS


### PR DESCRIPTION
Recently, I used a ST7789 1.69-inch TFT screen and used Setup24_ST7789.h to initialize the screen, but there was an offset as shown in the figure.
![IMG_20220228_115429R](https://user-images.githubusercontent.com/44105492/155921445-bdd0cc0a-10d6-4d93-af65-b3f5f935fef8.jpg)
After adding a new Setup202_ST7789.h file and modifying the ST7789_Rotation.h file, the screen seems to work normally.
![IMG_20220228_120020R](https://user-images.githubusercontent.com/44105492/155921966-59dfa4f0-7ec9-4b54-a369-419f3134cb01.jpg)

