### PR TITLE
Add ST7789 172x320 display support

### DIFF
--- a/TFT_Drivers/ST7789_Defines.h
+++ b/TFT_Drivers/ST7789_Defines.h
@@ -20,6 +20,13 @@
   #endif
 #endif
 
+// 1.47" 172x320 Round Rectangle Color IPS TFT Display
+#if (TFT_HEIGHT == 320) && (TFT_WIDTH == 172)
+  #ifndef CGRAM_OFFSET
+    #define CGRAM_OFFSET
+  #endif
+#endif
+
 // Delay between some initialisation commands
 #define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
 

--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -15,6 +15,11 @@
         colstart = 0;
         rowstart = 20;
       }
+      else if(_init_width == 172)
+      {
+        colstart = 34;
+        rowstart = 0;
+      }
       else
       {
         colstart = 0;
@@ -38,6 +43,11 @@
       {
         colstart = 20;
         rowstart = 0;
+      }
+      else if(_init_width == 172)
+      {
+        colstart = 0;
+        rowstart = 34;
       }
       else
       {
@@ -63,6 +73,11 @@
         colstart = 0;
         rowstart = 20;
       }
+      else if(_init_width == 172)
+      {
+        colstart = 34;
+        rowstart = 0;
+      }
       else
       {
         colstart = 0;
@@ -85,6 +100,11 @@
       {
         colstart = 20;
         rowstart = 0;
+      }
+      else if(_init_width == 172)
+      {
+        colstart = 0;
+        rowstart = 34;
       }
       else
       {

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -77,6 +77,7 @@
 // For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
 // #define TFT_WIDTH  80
 // #define TFT_WIDTH  128
+// #define TFT_WIDTH  172 // ST7789 172 x 320
 // #define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
 // #define TFT_HEIGHT 160
 // #define TFT_HEIGHT 128

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -85,7 +85,8 @@
 
 //#include <User_Setups/Setup70_ESP32_S2_ILI9341.h>  // Setup file for ESP32 S2 with SPI ILI9341
 
-//#include <User_Setups/Setup71_ESP32_S2_ST7789.h>  // Setup file for ESP32 S2 with ST7789
+//#include <User_Setups/Setup71_ESP32_S2_ST7789.h>       // Setup file for ESP32 S2 with ST7789
+//#include <User_Setups/Setup72_ESP32_ST7789_172x320.h>  // Setup file for ESP32 with ST7789 1.47" 172x320
 
 //#include <User_Setups/Setup100_RP2040_ILI9488_parallel.h>
 //#include <User_Setups/Setup101_RP2040_ILI9481_parallel.h>

--- a/User_Setups/Setup72_ESP32_ST7789_172x320.h
+++ b/User_Setups/Setup72_ESP32_ST7789_172x320.h
@@ -1,0 +1,30 @@
+// Support for 1.47" 320x172 Round Rectangle Color IPS TFT Display
+
+#define ST7789_DRIVER  // Full configuration option, define additional parameters below for this display
+
+#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
+#define TFT_WIDTH 172  // ST7789 172 x 320
+#define TFT_HEIGHT 320  // ST7789 240 x 320
+
+#define TFT_BL           21    // LED back-light control pin
+#define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
+
+#define TFT_MOSI 23
+#define TFT_SCLK 18
+#define TFT_CS   5   // Chip select control pin
+#define TFT_DC   22  // Data Command control pin
+#define TFT_RST  17  // Reset pin (could connect to RST pin)
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY 27000000

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -77,6 +77,7 @@
 // For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
 // #define TFT_WIDTH  80
 // #define TFT_WIDTH  128
+// #define TFT_WIDTH  172 // ST7789 172 x 320
 // #define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
 // #define TFT_HEIGHT 160
 // #define TFT_HEIGHT 128


### PR DESCRIPTION
Add support for 1.47" ST7789 172x320 display.

Adafruit announced the new display on Feb 21, 2022. There are several similar variants on Aliexpress.
https://www.adafruit.com/product/5393

I tested the code change on a bare display, it is mapping to a 240x320 area with an offset of 34.
`(240 - 172) / 2 = 34`

The display is tested in all 4 directions with the following code. The screen has a round corner, that's why the lines in the corners are invisible.

```c++
  tft.fillScreen(TFT_BLACK);

  tft.setRotation(0);

  tft.drawLine(0, 0, 0, 319, TFT_YELLOW);
  tft.drawLine(0, 0, 171, 0, TFT_RED);
  tft.drawLine(171, 0, 171, 319, TFT_GREEN);
  tft.drawLine(0, 319, 171, 319, TFT_BLUE);
```

![ST7789_172x320](https://user-images.githubusercontent.com/6889308/157462791-7524cf71-3995-4fa6-9cc8-c896d9ba7d49.png)