### PR TITLE
ESP-IDF compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+idf_component_register(SRCS "TFT_eSPI.cpp"
+                    INCLUDE_DIRS "."
+                    PRIV_REQUIRES arduino)
+
+add_definitions(-DTFT_eSPI_COMPONENT)

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,245 @@
+menu "TFT_eSPI"
+        
+    choice TFT_DRIVER
+        prompt "Select TFT driver"
+        default TFT_ILI9341_DRIVER
+        help
+            Driver for the TFT LCD screen
+
+        config TFT_ILI9341_DRIVER
+            bool "ILI9341 - 1"
+            help
+                Generic driver for common displays
+        config TFT_ILI9341_2_DRIVER
+            bool "ILI9341 - 2"
+            help
+                Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
+        config TFT_ST7735_DRIVER
+            bool "ST7735"
+            help
+                Define additional parameters below for this display
+        config TFT_ILI9163_DRIVER
+            bool "ILI9163"
+            help
+                Define additional parameters below for this display
+        config TFT_S6D02A1_DRIVER
+            bool "S6D02A1"
+        config TFT_ST7796_DRIVER
+            bool "ST7796"
+        config TFT_ILI9481_DRIVER
+            bool "ILI9481"
+        config TFT_ILI9486_DRIVER
+            bool "ILI9486"
+        config TFT_ILI9488_DRIVER
+            bool "ILI9488"
+            help
+                WARNING: Do not connect ILI9488 display SDO to MISO if other devices 
+                share the SPI bus (TFT SDO does NOT tristate when CS is high)
+    endchoice
+
+    config TFT_PARALLEL_8_BIT
+        bool "Enable 8-bit parallel mode (otherwise SPI is assumed)"
+        default "n"
+        help
+            Use 8-bit parallel bus to send data to the LCD. If not set SPI will be used.
+    
+    menu "Display Data pins"
+        visible if TFT_PARALLEL_8_BIT
+        config TFT_D0
+            int "Data 0 pin"
+            default -1
+            range -1 31
+
+        config TFT_D1
+            int "Data 1 pin"
+            default -1
+            range -1 31
+
+        config TFT_D2
+            int "Data 2 pin"
+            default -1
+            range -1 31
+        
+        config TFT_D3
+            int "Data 3 pin"
+            default -1
+            range -1 31
+
+        config TFT_D4
+            int "Data 4 pin"
+            default -1
+            range -1 31
+
+        config TFT_D5
+            int "Data 5 pin"
+            default -1
+            range -1 31
+
+        config TFT_D6
+            int "Data 6 pin"
+            default -1
+            range -1 31
+
+        config TFT_D7
+            int "Data 7 pin"
+            default -1
+            range -1 31
+
+        config TFT_WR
+            int "Write strobe pin"
+            default -1
+            range -1 31
+
+        config TFT_RD
+            int "Read strobe pin"
+            default -1
+            range -1 33
+    endmenu
+
+    menu "Display SPI config"
+        visible if !TFT_PARALLEL_8_BIT
+        config TFT_MISO
+            int "TFT MISO pin"
+            default -1
+            range -1 32
+            help
+                Master In Slave Out pin.
+                Can be labelled as SDO in some displays
+
+        config TFT_MOSI
+            int "TFT MOSI pin"
+            default -1
+            range -1 32
+            help
+                Master Out Slave In pin.
+                Can be labelled as SDA or SDI in some displays
+            
+        config TFT_SCLK
+            int "TFT Clock pin"
+            default -1
+            range -1 32
+            help
+                Labelled in some displays as WR
+
+        config TFT_SDA_READ
+            bool "Use SDA line for reading"
+            default "n"
+            help
+                Some displays support SPI reads via the MISO pin, other displays have a single
+                bi-directional SDA pin and the library will try to read this via the MOSI line
+
+        config TFT_SPI_FREQUENCY
+            int "SPI Frequency (Hz)"
+            default 27000000
+            range 1 80000000
+            help
+                Define the SPI clock frequency, this affects the graphics rendering speed. Too
+                fast and the TFT driver will not keep up and display corruption appears.
+                With an ILI9341 display 40MHz works OK, 80MHz sometimes fails
+                With a ST7735 display more than 27MHz may not work (spurious pixels and lines)
+                With an ILI9163 display 27 MHz works OK.
+
+        config TFT_SPI_READ_FREQ
+            int "SPI Read Frequency (Hz)"
+            default 20000000
+            range -1 80000000
+            help
+                Optional reduced SPI frequency for reading TFT.
+                Set to -1 to use the default frequency
+            
+    endmenu
+
+    menu "Control Pin configuration"
+        config TFT_CS
+            int "TFT Chip Select pin"
+            default -1
+            range -1 33
+    
+        config TFT_DC
+            int "TFT Data/Command pin"
+            default -1
+            range -1 31
+            help
+                Labelled as DC or RS (Register Select) in some displays
+    
+        config TFT_RST
+            int "TFT Reset pin"
+            default -1
+            range -1 33
+        
+        config TFT_BL
+            int "TFT Backlight pin"
+            default -1
+            range -1 33
+            help
+                Pin for the backlight control signal
+                Set to -1 to disable
+    
+        if TFT_BL >= 0
+            choice TFT_BACKLIGHT_ON
+                bool "Pin state to activate backlight"
+                default TFT_BACKLIGHT_ON_HIGH
+                help
+                    The backlight will be turned ON when tft.begin() is called, but the library
+                    needs to know if the LEDs are ON with the pin HIGH or LOW.
+        
+                config TFT_BACKLIGHT_ON_HIGH
+                    bool "HIGH"
+                config TFT_BACKLIGHT_ON_LOW
+                    bool "LOW"            
+            endchoice
+        endif
+    
+        config TFT_BACKLIGHT_ON
+            int
+            default 1 if TFT_BACKLIGHT_ON_HIGH
+            default 0 if TFT_BACKLIGHT_ON_LOW
+    endmenu
+
+    menu "Fonts"
+        config TFT_LOAD_GLCD
+            bool "Font 1: Original Adafruit 8 pixel font needs ~1820 bytes in FLASH"
+            default "y"
+
+        config TFT_LOAD_FONT2
+            bool "Font 2: Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters"
+            default "y"
+
+        config TFT_LOAD_FONT4
+            bool "Font 4: Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters"
+            default "y"
+
+        config TFT_LOAD_FONT6
+            bool "Font 6: Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm"
+            default "y"
+
+        config TFT_LOAD_FONT7
+            bool "Font 7: 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:."
+            default "y"
+
+        config TFT_LOAD_FONT8
+            bool "Font 8: Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-."
+            default "y"
+
+        config TFT_LOAD_GFXFF
+            bool "FreeFonts: Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts"
+            default "y"
+
+        config TFT_SMOOTH_FONT
+            bool "Smooth Fonts"
+            default "y"
+    endmenu
+    
+    menu "Touch screen configuration"
+        config TOUCH_CS
+            int "Touch chip select pin"
+            default -1
+            range -1 33
+
+        config SPI_TOUCH_FREQUENCY
+            int "SPI frequency for XPT2046 chip (Hz)"
+            default 2500000
+            range 1 80000000
+    endmenu
+
+endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -24,8 +24,8 @@ menu "TFT_eSPI"
                 Define additional parameters below for this display
         config TFT_S6D02A1_DRIVER
             bool "S6D02A1"
-        config TFT_ST7796_DRIVER
-            bool "ST7796"
+        config TFT_HX8357D_DRIVER
+            bool "HX8357D"
         config TFT_ILI9481_DRIVER
             bool "ILI9481"
         config TFT_ILI9486_DRIVER
@@ -35,7 +35,46 @@ menu "TFT_eSPI"
             help
                 WARNING: Do not connect ILI9488 display SDO to MISO if other devices 
                 share the SPI bus (TFT SDO does NOT tristate when CS is high)
+        config TFT_ST7789_DRIVER
+            bool "ST7789 - 1"
+            help
+                Full configuration option, define additional parameters below for this display
+        config TFT_ST7789_2_DRIVER
+            bool "ST7789 - 2"
+            help
+                Minimal configuration option, define additional parameters below for this display
+        config TFT_R61581_DRIVER
+            bool "R61581"
+        config TFT_RM68140_DRIVER
+            bool "RM68140"
+        config TFT_ST7796_DRIVER
+            bool "ST7796"
+        config TFT_SSD1351_DRIVER
+            bool "SSD1351"
+        config TFT_SSD1963_480_DRIVER
+            bool "SSD1963_480"
+        config TFT_SSD1963_800_DRIVER
+            bool "SSD1963_800"
+        config TFT_SSD1963_800ALT_DRIVER
+            bool "SSD1963_800ALT"
+        config TFT_ILI9225_DRIVER
+            bool "ILI9225"
+        config TFT_GC9A01_DRIVER
+            bool "GC9A01"
     endchoice
+
+    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9341_DRIVER || TFT_ILI9341_2_DRIVER
+        choice COLOR_ORDER
+            prompt "Define the colour order"
+            help
+                Define the colour order IF the blue and red are swapped on your display
+
+            config TFT_RGB_ORDER
+                bool "RGB"
+            config TFT_BGR_ORDER
+                bool "BGR"
+        endchoice
+    endif
 
     config TFT_PARALLEL_8_BIT
         bool "Enable 8-bit parallel mode (otherwise SPI is assumed)"

--- a/Kconfig
+++ b/Kconfig
@@ -64,7 +64,7 @@ menu "TFT_eSPI"
     endchoice
 
     if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9341_DRIVER || TFT_ILI9341_2_DRIVER
-        choice COLOR_ORDER
+        choice TFT_COLOR_ORDER
             prompt "Define the colour order"
             help
                 Define the colour order IF the blue and red are swapped on your display
@@ -75,6 +75,72 @@ menu "TFT_eSPI"
                 bool "BGR"
         endchoice
     endif
+
+    config TFT_M5STACK
+        bool "M5Stack"
+        depends on TFT_ILI9341_DRIVER || TFT_ILI9341_2_DRIVER
+        help
+            Enable if using M5Stack module with integrated ILI9341
+
+    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9163_DRIVER || TFT_GC9A01_DRIVER
+        config TFT_WIDTH
+            int "LCD pixel width in portrait orientation"
+            default 128
+            range 0 1024
+
+        config TFT_HEIGHT
+            int "LCD pixel height in portrait orientation"
+            default 240
+            range 0 1024
+    endif
+
+    if TFT_ST7735_DRIVER
+        choice TFT_ST7735_TYPE
+            prompt "Define the type of display"
+            help
+                Try out the different options below if the screen does not display graphics
+                correctly,e.g. colours wrong, mirror images, or stray pixels at the edges.
+
+            config TFT_ST7735_INITB
+                bool "INITB"
+            config TFT_ST7735_GREENTAB
+                bool "GREENTAB"
+            config TFT_ST7735_GREENTAB2
+                bool "GREENTAB2"
+            config TFT_ST7735_GREENTAB3
+                bool "GREENTAB3"
+            config TFT_ST7735_GREENTAB128
+                bool "GREENTAB128"
+                help
+                    For 128 x 128 display
+            config TFT_ST7735_GREENTAB160x80
+                bool "GREENTAB160x80"
+                help
+                    For 160 x 80 display (BGR, inverted, 26 offset)
+            config TFT_ST7735_REDTAB
+                bool "REDTAB"
+            config TFT_ST7735_BLACKTAB
+                bool "BLACKTAB"
+            config TFT_ST7735_REDTAB160x80
+                bool "REDTAB160x80"
+                help
+                    For 160 x 80 display with 24 pixel offset
+        endchoice
+    endif
+
+    choice TFT_COLOR_INVERSION
+        prompt "Color inversion correction"
+        help 
+            If colours are inverted (white shows as black) then try changing this option."
+
+        config TFT_INVERSION_DISABLE
+            bool "None"
+        config TFT_INVERSION_ON
+            bool "On"
+        config TFT_INVERSION_OFF
+            bool "Off"
+            
+    endchoice
 
     config TFT_PARALLEL_8_BIT
         bool "Enable 8-bit parallel mode (otherwise SPI is assumed)"

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -1,0 +1,220 @@
+/**
+ * @file   utility.h
+ * @author Ricard Bitriá Ribes (https://github.com/dracir9)
+ * Created Date: 22-01-2022
+ * -----
+ * Last Modified: 10-04-2022
+ * Modified By: Ricard Bitriá Ribes
+ * -----
+ * @copyright (c) 2022 Ricard Bitriá Ribes
+ */
+
+#ifndef TFT_CONFIG_H
+#define TFT_CONFIG_H
+
+#include "sdkconfig.h"
+
+/***************************************************************************************
+**                         TFT_eSPI Configuration defines
+***************************************************************************************/
+// Override defaults
+#define USER_SETUP_LOADED
+
+/***************************************************************************************
+**                         Section 1: Load TFT driver
+***************************************************************************************/
+#if defined (CONFIG_TFT_ILI9163_DRIVER)
+    #define ILI9163_DRIVER
+#elif defined(CONFIG_TFT_ILI9341_DRIVER)
+    #define ILI9341_DRIVER
+#elif defined(CONFIG_TFT_ILI9341_2_DRIVER)
+    #define ILI9341_2_DRIVER
+#elif defined (CONFIG_TFT_ILI9481_DRIVER)
+    #define ILI9481_DRIVER
+#elif defined (CONFIG_TFT_ILI9486_DRIVER)
+    #define ILI9486_DRIVER
+#elif defined (CONFIG_TFT_ILI9488_DRIVER)
+    #define ILI9488_DRIVER
+#elif defined (CONFIG_TFT_ST7735_DRIVER)
+    #define ST7735_DRIVER
+#elif defined (CONFIG_TFT_S6D02A1_DRIVER)
+    #define S6D02A1_DRIVER
+#elif defined (CONFIG_TFT_ST7796_DRIVER)
+    #define ST7796_DRIVER
+#endif
+
+
+/***************************************************************************************
+**                         Section 2: General Pin configuration
+***************************************************************************************/
+// General pins
+#if CONFIG_TFT_CS == -1
+    #error "Invalid Chip Select pin. Check TFT_eSPI configuration"
+#else
+    #define TFT_CS          CONFIG_TFT_CS
+#endif
+
+#if CONFIG_TFT_DC == -1
+    #error "Invalid Data/Command pin. Check TFT_eSPI configuration"
+#else
+    #define TFT_DC          CONFIG_TFT_DC
+#endif
+
+#if CONFIG_TFT_RST == -1
+    #error "Invalid Reset pin. Check TFT_eSPI configuration"
+#else
+    #define TFT_RST         CONFIG_TFT_RST
+#endif
+
+// Backlight config
+#if CONFIG_TFT_BL != -1
+    #define TFT_BL          CONFIG_TFT_BL
+    #define TFT_BACKLIGHT_ON CONFIG_TFT_BACKLIGHT_ON
+#endif
+
+
+/***************************************************************************************
+**                         Section 3: Data bus Pin configuration
+***************************************************************************************/
+
+// 8 BIT PARALLEL BUS
+#ifdef CONFIG_TFT_PARALLEL_8_BIT
+
+    #if CONFIG_TFT_D0 == -1
+        #error "Invalid Data 0 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D0      CONFIG_TFT_D0
+    #endif
+
+    #if CONFIG_TFT_D1 == -1
+        #error "Invalid Data 1 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D1      CONFIG_TFT_D1
+    #endif
+
+    #if CONFIG_TFT_D2 == -1
+        #error "Invalid Data 2 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D2      CONFIG_TFT_D2
+    #endif
+
+    #if CONFIG_TFT_D3 == -1
+        #error "Invalid Data 3 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D3      CONFIG_TFT_D3
+    #endif
+
+    #if CONFIG_TFT_D4 == -1
+        #error "Invalid Data 4 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D4      CONFIG_TFT_D4
+    #endif
+
+    #if CONFIG_TFT_D5 == -1
+        #error "Invalid Data 5 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D5      CONFIG_TFT_D5
+    #endif
+
+    #if CONFIG_TFT_D6 == -1
+        #error "Invalid Data 6 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D6      CONFIG_TFT_D6
+    #endif
+
+    #if CONFIG_TFT_D7 == -1
+        #error "Invalid Data 7 pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_D7      CONFIG_TFT_D7
+    #endif
+    
+    #if CONFIG_TFT_WR == -1
+        #error "Invalid Write strobe pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_WR      CONFIG_TFT_WR
+    #endif
+
+    #if CONFIG_TFT_RD == -1
+        #error "Invalid Read strobe pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_RD      CONFIG_TFT_RD
+    #endif
+
+// SPI BUS
+#else
+
+    #if CONFIG_TFT_MISO == -1
+        #error "Invalid MISO pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_MISO      CONFIG_TFT_MISO
+    #endif
+
+    #if CONFIG_TFT_MOSI == -1
+        #error "Invalid MOSI pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_MOSI      CONFIG_TFT_MOSI
+    #endif
+
+    #if CONFIG_TFT_SCLK == -1
+        #error "Invalid Clock pin. Check TFT_eSPI configuration"
+    #else
+        #define TFT_SCLK      CONFIG_TFT_SCLK
+    #endif
+
+    #define SPI_FREQUENCY   CONFIG_TFT_SPI_FREQUENCY
+
+    #if CONFIG_TFT_SPI_READ_FREQ != -1
+        #define SPI_READ_FREQUENCY CONFIG_TFT_SPI_READ_FREQ
+    #endif
+    
+    #ifdef CONFIG_TFT_SDA_READ
+        #define TFT_SDA_READ
+    #endif
+#endif
+
+
+/***************************************************************************************
+**                         Section 4: Setup Fonts
+***************************************************************************************/
+
+#ifdef CONFIG_TFT_LOAD_GLCD
+    #define LOAD_GLCD       // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#endif
+
+#ifdef CONFIG_TFT_LOAD_FONT2
+    #define LOAD_FONT2      // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#endif
+
+#ifdef CONFIG_TFT_LOAD_FONT4
+    #define LOAD_FONT4      // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#endif
+
+#ifdef CONFIG_TFT_LOAD_FONT6
+    #define LOAD_FONT6      // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#endif
+
+#ifdef CONFIG_TFT_LOAD_FONT7
+    #define LOAD_FONT7      // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#endif
+
+#ifdef CONFIG_TFT_LOAD_FONT8
+    #define LOAD_FONT8      // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#endif
+
+#ifdef CONFIG_TFT_LOAD_GFXFF
+    #define LOAD_GFXFF      // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+#endif
+
+#if CONFIG_TFT_SMOOTH_FONT
+    #define SMOOTH_FONT
+#endif
+
+/***************************************************************************************
+**                         Section 5: Touchscreen configuration
+***************************************************************************************/
+
+#define TOUCH_CS            CONFIG_TOUCH_CS
+
+#define SPI_TOUCH_FREQUENCY CONFIG_SPI_TOUCH_FREQUENCY
+
+#endif // TFT_CONFIG_H

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -3,7 +3,7 @@
  * @author Ricard Bitriá Ribes (https://github.com/dracir9)
  * Created Date: 22-01-2022
  * -----
- * Last Modified: 10-04-2022
+ * Last Modified: 11-04-2022
  * Modified By: Ricard Bitriá Ribes
  * -----
  * @copyright (c) 2022 Ricard Bitriá Ribes
@@ -23,26 +23,93 @@
 /***************************************************************************************
 **                         Section 1: Load TFT driver
 ***************************************************************************************/
-#if defined (CONFIG_TFT_ILI9163_DRIVER)
-    #define ILI9163_DRIVER
-#elif defined(CONFIG_TFT_ILI9341_DRIVER)
+#if defined (CONFIG_TFT_ILI9341_DRIVER)
     #define ILI9341_DRIVER
-#elif defined(CONFIG_TFT_ILI9341_2_DRIVER)
+#elif defined (CONFIG_TFT_ILI9341_2_DRIVER)
     #define ILI9341_2_DRIVER
+#elif defined (CONFIG_TFT_ST7735_DRIVER)
+    #define ST7735_DRIVER
+#elif defined (CONFIG_TFT_ILI9163_DRIVER)
+    #define ILI9163_DRIVER
+#elif defined (CONFIG_TFT_S6D02A1_DRIVER)
+    #define S6D02A1_DRIVER
+#elif defined (CONFIG_TFT_HX8357D_DRIVER)
+    #define HX8357D_DRIVER
 #elif defined (CONFIG_TFT_ILI9481_DRIVER)
     #define ILI9481_DRIVER
 #elif defined (CONFIG_TFT_ILI9486_DRIVER)
     #define ILI9486_DRIVER
 #elif defined (CONFIG_TFT_ILI9488_DRIVER)
     #define ILI9488_DRIVER
-#elif defined (CONFIG_TFT_ST7735_DRIVER)
-    #define ST7735_DRIVER
-#elif defined (CONFIG_TFT_S6D02A1_DRIVER)
-    #define S6D02A1_DRIVER
+#elif defined (CONFIG_TFT_ST7789_DRIVER)
+    #define ST7789_DRIVER
+#elif defined (CONFIG_TFT_ST7789_2_DRIVER)
+    #define ST7789_2_DRIVER
+#elif defined (CONFIG_TFT_R61581_DRIVER)
+    #define R61581_DRIVER
+#elif defined (CONFIG_TFT_RM68140_DRIVER)
+    #define RM68140_DRIVER
 #elif defined (CONFIG_TFT_ST7796_DRIVER)
     #define ST7796_DRIVER
+#elif defined (CONFIG_TFT_SSD1351_DRIVER)
+    #define SSD1351_DRIVER
+#elif defined (CONFIG_TFT_SSD1963_480_DRIVER)
+    #define SSD1963_480_DRIVER
+#elif defined (CONFIG_TFT_SSD1963_800_DRIVER)
+    #define SSD1963_800_DRIVER
+#elif defined (CONFIG_TFT_SSD1963_800ALT_DRIVER)
+    #define SSD1963_800ALT_DRIVER
+#elif defined (CONFIG_TFT_ILI9225_DRIVER)
+    #define ILI9225_DRIVER
+#elif defined (CONFIG_TFT_GC9A01_DRIVER)
+    #define GC9A01_DRIVER
 #endif
 
+#ifdef CONFIG_TFT_RGB_ORDER
+    #define TFT_RGB_ORDER TFT_RGB
+#endif
+
+#ifdef CONFIG_TFT_RGB_ORDER
+    #define TFT_RGB_ORDER TFT_BGR
+#endif
+
+#ifdef CONFIG_TFT_M5STACK
+    #define M5STACK
+#endif
+
+#ifdef CONFIG_TFT_WIDTH
+    #define TFT_WIDTH   CONFIG_TFT_WIDTH
+#endif
+
+#ifdef CONFIG_TFT_HEIGHT
+    #define TFT_HEIGHT   CONFIG_TFT_HEIGHT
+#endif
+
+#if defined (CONFIG_TFT_ST7735_INITB)
+    #define ST7735_INITB
+#elif defined (CONFIG_TFT_ST7735_GREENTAB)
+    #define ST7735_GREENTAB
+#elif defined (CONFIG_TFT_ST7735_GREENTAB2)
+    #define ST7735_GREENTAB2
+#elif defined (CONFIG_TFT_ST7735_GREENTAB3)
+    #define ST7735_GREENTAB3
+#elif defined (CONFIG_TFT_ST7735_GREENTAB128)
+    #define ST7735_GREENTAB128
+#elif defined (CONFIG_TFT_ST7735_GREENTAB160x80)
+    #define ST7735_GREENTAB160x80
+#elif defined (CONFIG_TFT_ST7735_REDTAB)
+    #define ST7735_REDTAB
+#elif defined (CONFIG_TFT_ST7735_BLACKTAB)
+    #define ST7735_BLACKTAB
+#elif defined (CONFIG_TFT_ST7735_REDTAB160x80)
+    #define ST7735_REDTAB160x80
+#endif
+
+#if defined (CONFIG_TFT_INVERSION_ON)
+    #define TFT_INVERSION_ON
+#elif defined (CONFIG_TFT_INVERSION_OFF)
+    #define TFT_INVERSION_OFF
+#endif
 
 /***************************************************************************************
 **                         Section 2: General Pin configuration

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -27,6 +27,10 @@
 ***************************************************************************************/
 
 //Standard support
+#ifdef TFT_eSPI_COMPONENT
+#include "TFT_config.h"
+#endif
+
 #include <Arduino.h>
 #include <Print.h>
 #include <SPI.h>


### PR DESCRIPTION
Added the necessary files for the library to be added as a component in an ESP-IDF project.

The library can be configure through `idf.py menuconfig`

Should not interfere with the already existing features.