### PR TITLE
user setup: increase SPI frequency on M5Stack Basic Core

### DIFF
--- a/User_Setups/Setup12_M5Stack_Basic_Core.h
+++ b/User_Setups/Setup12_M5Stack_Basic_Core.h
@@ -27,7 +27,7 @@
 #define SMOOTH_FONT
 
 
-#define SPI_FREQUENCY  27000000
+#define SPI_FREQUENCY  40000000
 
 // Optional reduced SPI frequency for reading TFT
-#define SPI_READ_FREQUENCY  5000000
+#define SPI_READ_FREQUENCY  16000000


### PR DESCRIPTION
The proposed values have been used for years in M5Stack's embedded copy of TFT_eSPI-- should be safe.

https://github.com/m5stack/M5Stack/blob/16db1b0b14982e89cf0def79be5f1bf682ccfc17/src/utility/In_eSPI_Setup.h#L262-L266