### PR TITLE
Fix ESP-IDF header include issue

### DIFF
--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -27,10 +27,6 @@
 ***************************************************************************************/
 
 //Standard support
-#ifdef TFT_eSPI_COMPONENT
-  #include "TFT_config.h"
-#endif
-
 #include <Arduino.h>
 #include <Print.h>
 #include <SPI.h>
@@ -40,6 +36,9 @@
 ***************************************************************************************/
 // Include header file that defines the fonts loaded, the TFT drivers
 // available and the pins to be used, etc, etc
+#ifdef CONFIG_TFT_eSPI_ESPIDF
+  #include "TFT_config.h"
+#endif
 #include <User_Setup_Select.h>
 
 // Handle FLASH based storage e.g. PROGMEM


### PR DESCRIPTION
Fix for issue introduced in commits 338d56ca4229619206ae166f42e63a36b55cddf8 and a815d77ec4b0435a1f0d96181ec58e25a7cc54f3. This caused the configuration from ESP-IDF menu to not be loaded.

The file `TFT_config.h` must be included after `Arduino.h` and before `User_Setup_Select.h` otherwhise it will not properly read the configuration and create the corresponding `#defines`