### PR TITLE
Fix Anti-Aliased drawing in parallel mode (#1960)

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -1158,6 +1158,8 @@ uint16_t TFT_eSPI::readPixel(int32_t x0, int32_t y0)
   #endif
 */
 
+  CS_H;
+
   #ifdef TFT_SDA_READ
     end_SDA_Read();
   #endif


### PR DESCRIPTION
Note: fixes #1960

As described in the issue, an oversight in the readPixel implementation prevents anti aliased drawing using the drawWedgeLine() method in parallel mode because the transaction state is not restored in the readPixel function when using parallel mode.

Changes:
 * Made parallel implementation of readPixel use the same methods to initialize the transfer and configure the CS pin as the SPI implementation (begin_tft_read() and end_tft_read()). This should work as these methods contain checks for parallel/SPI themselves, however I have only been able to confirm this with my specific hardware combo (described below)
 * Added the restoring functionality of the inTransaction flag and the transaction state to the parallel implementation which was previously only present in the SPI implementation.
 * Moved the duplicate code that is now present in both the parallel and SPI implementations out of the parallel/SPI #ifdef statement so it is less confusing to update in the future. In theory this should not have modified the SPI implementation functionality wise but I do not have any SPI displays to test this with so it should be tested for compilation/runtime errors before merging.

As I am not able to test every scenario this might be used in and I certainly don't know every possible scenario so it is very likely I have missed something that breaks some other code. I would be happy if someone notifies me or fixes the issue if one is found. 

My hardware:
8-Bit parallel ILI9341 driver connected to ESP32 (WROOM32 on Generic ESP32 Dev Module)