### PR TITLE
ST7735: fix RGB/BGR selection

### DIFF
--- a/TFT_Drivers/ST7735_Defines.h
+++ b/TFT_Drivers/ST7735_Defines.h
@@ -17,6 +17,7 @@
 #define INITR_GREENTAB128    0x5 // Use if you only get part of 128x128 screen in rotation 0 & 1
 #define INITR_GREENTAB160x80 0x6 // Use if you only get part of 128x128 screen in rotation 0 & 1
 #define INITR_REDTAB160x80   0x7 // Added for https://www.aliexpress.com/item/ShengYang-1pcs-IPS-0-96-inch-7P-SPI-HD-65K-Full-Color-OLED-Module-ST7735-Drive/32918394604.html
+#define INITR_ROBOTLCD       0x8
 #define INITB                0xB
 
 
@@ -42,6 +43,10 @@
  
 #elif defined (ST7735_GREENTAB160x80)
   #define TAB_COLOUR INITR_GREENTAB160x80
+  #define CGRAM_OFFSET
+
+#elif defined (ST7735_ROBOTLCD)
+  #define TAB_COLOUR INITR_ROBOTLCD
   #define CGRAM_OFFSET
 
 #elif defined (ST7735_REDTAB160x80)

--- a/TFT_Drivers/ST7735_Defines.h
+++ b/TFT_Drivers/ST7735_Defines.h
@@ -107,7 +107,7 @@
 #define TFT_MAD_RGB 0x00
 
 #ifndef TFT_RGB_ORDER
-  #if defined(INITR_BLACKTAB) || defined(INITR_GREENTAB2) || defined(INITB)
+  #if defined(ST7735_BLACKTAB) || defined(ST7735_GREENTAB2) || defined(ST7735_INITB)
     #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
   #else
     #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR

--- a/TFT_Drivers/ST7735_Init.h
+++ b/TFT_Drivers/ST7735_Init.h
@@ -123,6 +123,17 @@
       0x00, 0x00,             //     XSTART = 0
       0x00, 0x9F },           //     XEND = 159
 
+  // Frame control init for RobotLCD, taken from https://github.com/arduino-libraries/TFT, Adafruit_ST7735.cpp l. 263, commit 61b8a7e
+  Rcmd3RobotLCD[] = {
+      3,
+      ST7735_FRMCTR1, 2    ,  //  1: Frame rate ctrl - normal mode, 2 args
+        0x0B, 0x14,
+      ST7735_FRMCTR2, 2    ,  //  2: Frame rate ctrl - idle mode, 2 args
+        0x0B, 0x14,
+      ST7735_FRMCTR3, 4    ,  //  3: Frame rate ctrl - partial mode, 4 args
+        0x0B, 0x14,
+        0x0B, 0x14 },
+
   Rcmd3[] = {                 // Init for 7735R, part 3 (red or green tab)
     4,                        //  4 commands in list:
     ST7735_GMCTRP1, 16      , //  1: 16 args, no delay:
@@ -180,6 +191,11 @@
          writecommand(TFT_INVON);
          colstart = 26;
          rowstart = 1;
+       }
+       else if (tabcolor == INITR_ROBOTLCD)
+       {
+         commandList(Rcmd2green);
+         commandList(Rcmd3RobotLCD);
        }
        else if (tabcolor == INITR_REDTAB160x80)
        {

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -104,6 +104,7 @@
 // #define ST7735_GREENTAB3
 // #define ST7735_GREENTAB128    // For 128 x 128 display
 // #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
+// #define ST7735_ROBOTLCD       // For some RobotLCD arduino shields (128x160, BGR, https://docs.arduino.cc/retired/getting-started-guides/TFT)
 // #define ST7735_REDTAB
 // #define ST7735_BLACKTAB
 // #define ST7735_REDTAB160x80   // For 160 x 80 display with 24 pixel offset


### PR DESCRIPTION
I think there is a confusion in ST7735_Defines.h.
We check if INITR_XXX is defined instead of checking the user defines set in User_Setup.h (ST7735_XXX)
Since INITR_XXX are always defined, we always end up using RGB, except when manually defining the color order in User_Setup.h.
This change fixes inverted colors on my board using a RobotLCD shield.