### PR TITLE
Fix typo and remove unnecessary error in TFT_config.h

### DIFF
--- a/TFT_config.h
+++ b/TFT_config.h
@@ -78,7 +78,7 @@
     #define TFT_RGB_ORDER TFT_RGB
 #endif
 
-#ifdef CONFIG_TFT_RGB_ORDER
+#ifdef CONFIG_TFT_BGR_ORDER
     #define TFT_RGB_ORDER TFT_BGR
 #endif
 
@@ -223,9 +223,7 @@
 
 // SPI BUS
 #else
-    #if CONFIG_TFT_MISO == -1
-        #error "Invalid MISO pin. Check TFT_eSPI configuration"
-    #else
+    #if CONFIG_TFT_MISO != -1
         #define TFT_MISO      CONFIG_TFT_MISO
     #endif
 


### PR DESCRIPTION
1. RGB configuration was configured incorrectly, and caused re-definition warnings.
2. MISO pin is not always set, so shouldn't trigger a compilation error (see e.g. `Setup25_TTGO_T_DISPLAY.h`).