### PR TITLE
Fixed memory leak when using createPalette from FLASH

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -254,6 +254,11 @@ void TFT_eSprite::createPalette(uint16_t colorMap[], uint8_t colors)
 ***************************************************************************************/
 void TFT_eSprite::createPalette(const uint16_t colorMap[], uint8_t colors)
 {
+  if (_colorMap != nullptr)
+  {
+    free(_colorMap);
+  }
+
   if (colorMap == nullptr)
   {
     // Create a color map using the default FLASH map


### PR DESCRIPTION
Memory taken by previous _colorMap was not freed when calling createPalette (from FLASH array)