### PR TITLE
Add esp32-s3-box-lite display configuration

### DIFF
--- a/User_Setups/Setup208_ESP32_S3_Box_Lite.h
+++ b/User_Setups/Setup208_ESP32_S3_Box_Lite.h
@@ -1,0 +1,32 @@
+// Display configuration for ST7789-based ESP32-S3-Box-Lite(https://amzn.to/3XiJkUW)
+
+#define USER_SETUP_ID 208
+#define USER_SETUP_INFO "ESP32-S3-BOX-LITE"
+
+#define ST7789_DRIVER
+#define TFT_RGB_ORDER TFT_BGR
+
+#define TFT_WIDTH  240
+#define TFT_HEIGHT 320
+
+#define TFT_BL   45
+#define TFT_BACKLIGHT_ON LOW
+
+#define TFT_CS   5
+#define TFT_DC   4
+#define TFT_RST  48
+
+#define TFT_MOSI 6
+#define TFT_SCLK 7
+
+#define LOAD_GLCD 
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY  40000000


### PR DESCRIPTION
Not sure if this is the canonical way to add a user configuration, but here's a config for the ESP32-S3-Box-Lite module without a touchscreen. Can likely serve for the display portion of the ESP32-S3-Box as well.