### PR TITLE
Fix TFT_ring_meter.ino example build

### DIFF
--- a/examples/480 x 320/TFT_ring_meter/TFT_ring_meter.ino
+++ b/examples/480 x 320/TFT_ring_meter/TFT_ring_meter.ino
@@ -15,7 +15,7 @@
 
 #define TFT_GREY 0x2104 // Dark grey 16 bit colour
 
-#include "alert.h" // Out of range alert icon
+#include "Alert.h" // Out of range alert icon
 
 #include <TFT_eSPI.h> // Hardware-specific library
 #include <SPI.h>


### PR DESCRIPTION
Fix TFT_ring_meter.ino example build: typo in the include file.