### PR TITLE
8 bit parallel fix for ESP-IDF

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -150,12 +150,16 @@ menu "TFT_eSPI"
             
     endchoice
 
-    config TFT_PARALLEL_8_BIT
-        bool "Enable 8-bit parallel mode (otherwise SPI is assumed)"
-        default "n"
-        depends on IDF_TARGET_ESP32
+    choice TFT_INTERFACE
+        prompt "LCD Interface"
+        default TFT_SPI
         help
-            Use 8-bit parallel bus to send data to the LCD. If not set SPI will be used.
+            Communication interface between the microcontroller and the LCD.
+        config TFT_SPI
+            bool "SPI"
+        config TFT_PARALLEL_8_BIT
+            bool "Parallel (8 bit)"
+    endchoice
     
     menu "Display Data pins"
         depends on TFT_PARALLEL_8_BIT
@@ -211,7 +215,7 @@ menu "TFT_eSPI"
     endmenu
 
     menu "Display SPI config"
-        depends on !TFT_PARALLEL_8_BIT
+        depends on TFT_SPI
     
         choice TFT_SPI_PORT
             prompt "SPI port"
@@ -232,6 +236,7 @@ menu "TFT_eSPI"
             default -1
             range -1 32 if IDF_TARGET_ESP32
             range -1 45 if IDF_TARGET_ESP32S2
+            range -1 48 if IDF_TARGET_ESP32S2
             help
                 Master In Slave Out pin.
                 Can be labelled as SDO in some displays
@@ -241,6 +246,7 @@ menu "TFT_eSPI"
             default -1
             range -1 32 if IDF_TARGET_ESP32
             range -1 45 if IDF_TARGET_ESP32S2
+            range -1 48 if IDF_TARGET_ESP32S2
             help
                 Master Out Slave In pin.
                 Can be labelled as SDA or SDI in some displays
@@ -250,6 +256,7 @@ menu "TFT_eSPI"
             default -1
             range -1 32 if IDF_TARGET_ESP32
             range -1 45 if IDF_TARGET_ESP32S2
+            range -1 48 if IDF_TARGET_ESP32S2
             help
                 Labelled in some displays as WR
 
@@ -287,6 +294,7 @@ menu "TFT_eSPI"
             default -1
             range -1 33 if IDF_TARGET_ESP32
             range -1 45 if IDF_TARGET_ESP32S2
+            range -1 48 if IDF_TARGET_ESP32S2
     
         config TFT_DC
             int "TFT Data/Command pin"
@@ -300,6 +308,7 @@ menu "TFT_eSPI"
             default -1
             range -1 33 if IDF_TARGET_ESP32
             range -1 45 if IDF_TARGET_ESP32S2
+            range -1 48 if IDF_TARGET_ESP32S2
 
         config ENABLE_BL
             bool "Enable backlight control"
@@ -311,6 +320,7 @@ menu "TFT_eSPI"
                 default -1
                 range -1 33 if IDF_TARGET_ESP32
                 range -1 45 if IDF_TARGET_ESP32S2
+                range -1 48 if IDF_TARGET_ESP32S2
                 help
                     Pin for the backlight control signal
         
@@ -379,6 +389,7 @@ menu "TFT_eSPI"
                 default -1
                 range -1 33 if IDF_TARGET_ESP32
                 range -1 45 if IDF_TARGET_ESP32S2
+                range -1 48 if IDF_TARGET_ESP32S2
 
             config SPI_TOUCH_FREQUENCY
                 int "SPI frequency for XPT2046 chip (Hz)"

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -12,7 +12,7 @@
  * @author Ricard Bitriá Ribes (https://github.com/dracir9)
  * Created Date: 22-01-2022
  * -----
- * Last Modified: 14-04-2022
+ * Last Modified: 20-02-2023
  * Modified By: Ricard Bitriá Ribes
  * -----
  * @copyright (c) 2022 Ricard Bitriá Ribes
@@ -160,6 +160,8 @@
 
 // 8 BIT PARALLEL BUS
 #ifdef CONFIG_TFT_PARALLEL_8_BIT
+
+    #define TFT_PARALLEL_8_BIT
 
     #if CONFIG_TFT_D0 == -1
         #error "Invalid Data 0 pin. Check TFT_eSPI configuration"


### PR DESCRIPTION
Fixed a missing define that prevented using 8-bit parallel bus on ESP-IDF.
Simplified the LCD interface selection (SPI/Parallel) and added the available pin ranges for ESP32-S3