### PR TITLE
Add ESP32-S3 Box support

### DIFF
--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -135,11 +135,12 @@
 //#include <User_Setups/Setup206_LilyGo_T_Display_S3.h>     // For the LilyGo T-Display S3 based ESP32S3 with ST7789 170 x 320 TFT
 //#include <User_Setups/Setup207_LilyGo_T_HMI.h>            // For the LilyGo T-HMI S3 based ESP32S3 with ST7789 240 x 320 TFT
 
-//#include <User_Setups/Setup208_ESP32_S3_Box_Lite.h>      // For the ESP32 S3 Box Lite (may also work with ESP32 S3 Box)
+//#include <User_Setups/Setup208_ESP32_S3_Box_Lite.h>      // For the ESP32 S3 Box Lite
 
 //#include <User_Setups/Setup209_LilyGo_T_Dongle_S3.h>      // For the LilyGo T-Dongle S3 based ESP32 with ST7735 80 x 160 TFT
-// #include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
-// #include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
+//#include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT
+//#include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
+//#include <User_Setups/Setup212_ESP32_S3_Box.h>            // For the ESP32 S3 Box
 
 //#include <User_Setups/Setup301_BW16_ST7735.h>            // Setup file for Bw16-based boards with ST7735 160 x 80 TFT
 

--- a/User_Setups/Setup212_ESP32_S3_Box.h
+++ b/User_Setups/Setup212_ESP32_S3_Box.h
@@ -1,0 +1,28 @@
+// Display configuration for ILI9342-based ESP32-S3-Box
+
+#define USER_SETUP_ID 212
+#define USER_SETUP_INFO "ESP32-S3-BOX"
+
+#define M5STACK // Uses the same ILI9342 display, dont remove
+
+#define ILI9341_DRIVER
+
+#define TFT_MISO 0
+#define TFT_MOSI 6
+#define TFT_SCLK 7
+#define TFT_CS 5   // Chip select control pin
+#define TFT_DC 4   // Data Command control pin
+#define TFT_RST 48 // Reset pin (could connect to Arduino RESET pin)
+#define TFT_BL 45  // LED back-light
+
+#define LOAD_GLCD  // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2 // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4 // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6 // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7 // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8 // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY 27000000


### PR DESCRIPTION
This adds support for the ESP32-S3 Box. Driver support was previously added as the ESP32-S3 Box uses the same ILI9342 display chip as the M5Stack Core2. So, I've included the `M5Stack` define which modifies the ILI9341 driver for the ILI9342. This with the proper tft pins works for the ESP32-S3 Box.

Here is an example project I made using this setup file: https://github.com/RileyCornelius/Esp32-Box-Lvgl-Example

