### PR TITLE
Make CONFIG_TFT_RST optional

### DIFF
--- a/TFT_config.h
+++ b/TFT_config.h
@@ -24,6 +24,14 @@
 #include "sdkconfig.h"
 
 /***************************************************************************************
+**                         Others
+***************************************************************************************/
+
+#ifdef CONFIG_DISABLE_WARNINGS
+    #define DISABLE_ALL_LIBRARY_WARNINGS
+#endif
+
+/***************************************************************************************
 **                         TFT_eSPI Configuration defines
 ***************************************************************************************/
 // Override defaults
@@ -137,7 +145,9 @@
 #endif
 
 #if CONFIG_TFT_RST == -1
-    #error "Invalid Reset pin. Check TFT_eSPI configuration"
+    #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
+        #warning "Invalid Reset pin. Check TFT_eSPI configuration"
+    #endif
 #else
     #define TFT_RST         CONFIG_TFT_RST
 #endif
@@ -305,14 +315,6 @@
     #endif
 
     #define SPI_TOUCH_FREQUENCY CONFIG_SPI_TOUCH_FREQUENCY
-#endif
-
-/***************************************************************************************
-**                         Section 6: Others
-***************************************************************************************/
-
-#ifdef CONFIG_DISABLE_WARNINGS
-    #define DISABLE_ALL_LIBRARY_WARNINGS
 #endif
 
 #endif // TFT_CONFIG_H


### PR DESCRIPTION
Hi!

Thanks for maintaining such a great library!

I'm using esp-idf with a esp32-c3 and st7789 screen. With this setup the RST pin is optional. However in TFT_config.h not setting the reset pin throws an error. This PR changes that to throw a warning instead, and moves the CONFIG_DISABLE_WARNINGS setting to the top of the file so that you can disable the warnings also in TFT_config.h.

This brings the esp-idf compatibility more in line with the rest of the library to where RST pins are not always set.