### PR TITLE
For ESP32-S3 and TFT_PARALLEL_8_BIT, bitbang 20%-30% faster

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -551,7 +551,13 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
     #endif
   #endif
   }
-  else while (len--) {tft_Write_16(color);}
+  else {
+    tft_Write_16(color);
+    --len;
+    HACKIT(true);
+    while (len--) {tft_Write_16(color);}
+    HACKIT(false);
+  }
 }
 
 /***************************************************************************************
@@ -561,7 +567,12 @@ void TFT_eSPI::pushBlock(uint16_t color, uint32_t len){
 void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
 
   uint16_t *data = (uint16_t*)data_in;
+  tft_Write_16(*data);
+  data++;
+  --len;
+  HACKIT(true);
   while ( len-- ) {tft_Write_16(*data); data++;}
+  HACKIT(false);
 }
 
 /***************************************************************************************
@@ -569,10 +580,24 @@ void TFT_eSPI::pushSwapBytePixels(const void* data_in, uint32_t len){
 ** Description:             Write a sequence of pixels
 ***************************************************************************************/
 void TFT_eSPI::pushPixels(const void* data_in, uint32_t len){
-
+  
   uint16_t *data = (uint16_t*)data_in;
-  if(_swapBytes) { while ( len-- ) {tft_Write_16(*data); data++; } }
-  else { while ( len-- ) {tft_Write_16S(*data); data++;} }
+  if(_swapBytes) { 
+    tft_Write_16(*data);
+    data++;
+    --len;
+    HACKIT(true);
+    while ( len-- ) {tft_Write_16(*data); data++; }
+    HACKIT(false);
+  }
+  else { 
+    tft_Write_16S(*data);
+    data++;
+    --len;
+    HACKIT(true);
+    while ( len-- ) {tft_Write_16S(*data); data++;} 
+    HACKIT(false);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -409,7 +409,15 @@ SPI3_HOST = 2
   //*/
 
   // Write 8 bits to TFT
-  #define tft_Write_8(C)  GPIO_CLR_REG =  GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t)(C)); WR_H
+  #define SUPER_SPECIFIC_ESP32_S3_9BITPARALLEL_HACK_OMG_WHAT_IS_THIS_MACRO_NIGHMARE
+  #ifdef SUPER_SPECIFIC_ESP32_S3_9BITPARALLEL_HACK_OMG_WHAT_IS_THIS_MACRO_NIGHMARE
+  static bool _hackit_ = false;
+  #define HACKIT(C) _hackit_ = C;
+  #else
+  static bool _hackit_ = false;
+  #define HACKIT(C) (void(0))
+  #endif
+  #define tft_Write_8(C)  GPIO.out_w1tc = GPIO_OUT_CLR_MASK; GPIO.out_w1ts = set_mask((uint8_t)(C)) | (_hackit_?(1<<TFT_WR):0); if (!_hackit_) WR_H
 
   #if defined (SSD1963_DRIVER)
 
@@ -429,12 +437,12 @@ SPI3_HOST = 2
       #define tft_Write_16S(C) GPIO.out_w1tc = GPIO_OUT_CLR_MASK; GPIO.out_w1ts = set_mask((uint8_t) ((C) >> 8)); WR_H
     #else
       // Write 16 bits to TFT
-      #define tft_Write_16(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
-                              GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H
+      #define tft_Write_16(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)) | (_hackit_?(1<<TFT_WR):0); if (!_hackit_) WR_H; \
+                              GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)) | (_hackit_?(1<<TFT_WR):0); if (!_hackit_) WR_H
 
       // 16 bit write with swapped bytes
-      #define tft_Write_16S(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
-                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H
+      #define tft_Write_16S(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)) | (_hackit_?(1<<TFT_WR):0); if (!_hackit_) WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)) | (_hackit_?(1<<TFT_WR):0); if (!_hackit_) WR_H
     #endif
 
   #endif


### PR DESCRIPTION
So I was experimenting with my own library for this parallel setup and my sole ESP32-S3 board and I was looking at the assembler output for a single pixel write.  Before this hack, the best we could do was 3 stores (s32i instructions) per byte written out to the TFT.

For each data byte, these register writes happen:

1. Pulls the WR line LOW in the same GPIO "clear" register write where one also sets the data lines which are low;

2. Perform a GPIO "set" register write for the high data lines.

3. Perform a third "set" register write just for pulling the WR line high.

This commit, which for now is only a hack, conflates steps 2 and 3 for any byte that is not the first byte after a command.

So only 2 stores per byte, which is theoretically a 33% maximum improvement.

The stores in the Xtensa LX7 allow for some wait cycles (around 30 or so), so it stills gives time to do the current run-time solution of adjusting the result of the 'set_mask' lookup.  But with more lookup tables even this could be avoided, so there's still room for improvement.

* Processors/TFT_eSPI_ESP32_S3.c (pushBlock) (pushSwapBytePixels)
(pushPixels): Use HACKIT(bool) macro.

* Processors/TFT_eSPI_ESP32_S3.h (_hackit_): new global.
(SUPER_SPECIFIC_ESP32_S3_9BITPARALLEL_HACK, HACKIT): New defines (tft_Write_8 (within define))
(tft_Write_16 (within define))
(tft_Write_16S (within define)): Use _hackit_.