### PR TITLE
ESP32 Parallel DMA support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,15 @@
 
 idf_component_register(SRCS "TFT_eSPI.cpp"
                     INCLUDE_DIRS "."
-                    PRIV_REQUIRES arduino)
+                    PRIV_REQUIRES "arduino")
+
+function(maybe_add_component component_name)
+    idf_build_get_property(components BUILD_COMPONENTS)
+    message(STATUS "Components: ${components}")
+    if (${component_name} IN_LIST components)
+        idf_component_get_property(lib_name ${component_name} COMPONENT_LIB)
+        target_link_libraries(${COMPONENT_LIB} PUBLIC ${lib_name})
+    endif()
+endfunction()
+
+maybe_add_component(esp_lcd)

--- a/Kconfig
+++ b/Kconfig
@@ -344,6 +344,39 @@ menu "TFT_eSPI"
             default 0 if TFT_BACKLIGHT_ON_LOW
     endmenu
 
+    menu "Parallel DMA configuration"
+        depends on TFT_PARALLEL_8_BIT
+
+        config DMA_FREQUENCY
+            int "Bus frequency (Hz)"
+            default 4000000
+            range 1250000 80000000
+            help
+                Theoretical maximum frequency for 8-bit parallel bus is 80 MHz. Use lower values if
+                visual glitches apperar or the module crashes or hangs frequently
+
+        config DMA_MAX_TX_SIZE
+            int "Max transfer size (Bytes)"
+            default 65536
+            range 1 8388608
+            help
+                Maximum number of bytes that can be transferred in a single DMA operation. This is the
+                largest block of data that can be sent using pushImageDMA or pushPixelsDMA without
+                blocking code execution.
+                
+                Large transfer sizes require more memory for internal DMA data structures (12 Bytes
+                for every 4095 Bytes of maximum transfer size)
+
+        config DMA_SWAP_BYTES
+            bool "Swap bytes"
+            default "y"
+            help
+                Swap byte order when sending color data. This produces the same effect as calling
+                setSwapBytes but the operation is handled by hardware rather than software which
+                increases performance.
+
+    endmenu
+
     menu "Fonts"
         config TFT_LOAD_GLCD
             bool "Font 1: Original Adafruit 8 pixel font needs ~1820 bytes in FLASH"

--- a/Kconfig
+++ b/Kconfig
@@ -367,6 +367,29 @@ menu "TFT_eSPI"
                 Large transfer sizes require more memory for internal DMA data structures (12 Bytes
                 for every 4095 Bytes of maximum transfer size)
 
+        config DMA_FAST_TRANSFER 
+            bool "DMA transfer optimization"
+            default "n"
+            help
+                By enabling this setting the TFT_DMA_MAX_TX_SIZE can be significantly reduced while mantaining
+                the same level of performance. As a result the overall memory usage is lower
+                
+                MORE TESTING NEEEDED!!!
+                
+                When transfering data using DMA that exceeds TFT_DMA_MAX_TX_SIZE we have to
+                wait for the current transaction to complete. If this setting is disabled the
+                transferred image is divided in smaller rectangles that fit in a single DMA operation
+                This requires updating the display address window for each block.
+                
+                Some displays allow to pause pixel data transfers and resume them later if no
+                commands have been sent in between. Therefore we could set the address window once
+                and send color data in multiple transfers.
+                
+                Even if the display supports it there may be project configurations or user code that
+                interferes with this optimization. The result is that only the first transfer is valid
+                and the following ones are ignored. As a consequence only a portion of the total buffer
+                is displayed
+
         config DMA_SWAP_BYTES
             bool "Swap bytes"
             default "y"

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -701,21 +701,21 @@ void TFT_eSPI::pushPixelsDMA(uint16_t* image, uint32_t len)
 #elif defined(ESP32_DMA_PARALLEL)
 
   // Buffer is larger than max transfer size of 64 kBytes
-  if (len > 32768)
+  if (len > TFT_DMA_MAX_TX_SIZE/2)
   {
-    // Send command and first 64 kB block
-    ret = esp_lcd_panel_io_tx_color(lcd_io_handle, TFT_RAMWR, image, 65536);
+    // Send command and first block
+    ret = esp_lcd_panel_io_tx_color(lcd_io_handle, TFT_RAMWR, image, TFT_DMA_MAX_TX_SIZE/2 *2);
     assert(ret == ESP_OK);
-    len -= 32768; image+= 32768;
+    len -= TFT_DMA_MAX_TX_SIZE/2; image+= TFT_DMA_MAX_TX_SIZE/2;
 
     // Keep sending 64 kB blocks
-    while(len > 32768)
+    while(len > TFT_DMA_MAX_TX_SIZE/2)
     {
       // If the dma is busy, the LCD driver will queue the transaction.
       // If the queue is full it will block execution and wait for the current transaction to finish.
       ret = esp_lcd_panel_io_tx_color(lcd_io_handle, -1, image, 65536); // If command is negative no command is sent
       assert(ret == ESP_OK);
-      len -= 32768; image+= 32768;
+      len -= TFT_DMA_MAX_TX_SIZE/2; image+= TFT_DMA_MAX_TX_SIZE/2;
     }
 
     // Send last batch of data

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -928,7 +928,7 @@ bool TFT_eSPI::initDMA(bool ctrl_cs)
       TFT_D7
     },
     .bus_width = 8,
-    .max_transfer_bytes = 65536,
+    .max_transfer_bytes = TFT_DMA_MAX_TX_SIZE,
     .psram_trans_align = 0,
     .sram_trans_align = 0
   };
@@ -936,8 +936,8 @@ bool TFT_eSPI::initDMA(bool ctrl_cs)
 
   const esp_lcd_panel_io_i80_config_t io_config = {
     .cs_gpio_num = TFT_CS,
-    .pclk_hz = SPI_FREQUENCY,
-    .trans_queue_depth = 10,
+    .pclk_hz = TFT_DMA_FREQUENCY,
+    .trans_queue_depth = 1,
     .on_color_trans_done = NULL,
     .user_ctx = NULL,
     .lcd_cmd_bits = 8,
@@ -951,7 +951,7 @@ bool TFT_eSPI::initDMA(bool ctrl_cs)
     .flags = {
       .cs_active_high = 0,
       .reverse_color_bits = 0,
-      .swap_color_bytes = 0,
+      .swap_color_bytes = TFT_DMA_SWAP_BYTES,
       .pclk_active_neg = 0,
       .pclk_idle_low = 0
     }

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -755,25 +755,16 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
   esp_err_t ret = ESP_OK;
 
 #if defined(ESP32_DMA)
-
   setAddrWindow(x, y, w, h);
-  
-  bool temp = _swapBytes;
-  _swapBytes = false;
-  pushPixelsDMA(buffer, len);
-  _swapBytes = temp;
-
 #elif defined(ESP32_DMA_PARALLEL)
-
   ret = setAddrWindowDMA(x, y, w, h);
   assert(ret == ESP_OK);
+#endif
 
   bool temp = _swapBytes;
   _swapBytes = false;
   pushPixelsDMA(buffer, len);
   _swapBytes = temp;
-
-#endif
 }
 
 
@@ -835,27 +826,17 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
   esp_err_t ret = ESP_OK;
 
 #if defined(ESP32_DMA)
-
   if (spiBusyCheck) dmaWait(); // In case we did not wait earlier
-
   setAddrWindow(x, y, dw, dh);
-
-  bool temp = _swapBytes;
-  _swapBytes = false;
-  pushPixelsDMA(buffer, len);
-  _swapBytes = temp;
-
 #elif defined(ESP32_DMA_PARALLEL)
-
   ret = setAddrWindowDMA(x, y, dw, dh);
   assert(ret == ESP_OK);
+#endif
 
   bool temp = _swapBytes;
   _swapBytes = false;
   pushPixelsDMA(buffer, len);
   _swapBytes = temp;
-
-#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -652,7 +652,7 @@ void TFT_eSPI::dmaWait(void)
   spiBusyCheck = 0;
 
 #elif defined(ESP32_DMA_PARALLEL)
-
+  
 #endif
 }
 
@@ -852,14 +852,8 @@ extern "C" void dc_callback();
 
 void IRAM_ATTR dc_callback(spi_transaction_t *spi_tx)
 {
-#if defined(ESP32_DMA)
-
   if ((bool)spi_tx->user) {DC_D;}
   else {DC_C;}
-
-#elif defined(ESP32_DMA_PARALLEL)
-
-#endif
 }
 
 /***************************************************************************************
@@ -870,11 +864,7 @@ extern "C" void dma_end_callback();
 
 void IRAM_ATTR dma_end_callback(spi_transaction_t *spi_tx)
 {
-#if defined(ESP32_DMA)
   WRITE_PERI_REG(SPI_DMA_CONF_REG(spi_host), 0);
-#elif defined(ESP32_DMA_PARALLEL)
-
-#endif
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -758,22 +758,22 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
   // Buffer is larger than max transfer size
   if (len > TFT_DMA_MAX_TX_SIZE/2)
   {
-    dh = TFT_DMA_MAX_TX_SIZE/2 / dw;
+    h = TFT_DMA_MAX_TX_SIZE/2 / w;
 
     do {
-      ret = setAddrWindowDMA(x, y, dw, dh);
+      ret = setAddrWindowDMA(x, y, w, h);
       assert(ret == ESP_OK);
 
-      ret = esp_lcd_panel_io_tx_color(lcd_io_handle, TFT_RAMWR, image, dw*dh*2);
+      ret = esp_lcd_panel_io_tx_color(lcd_io_handle, TFT_RAMWR, image, w*h*2);
       assert(ret == ESP_OK);
-      len -= dw*dh; image+= dw*dh; y += dh;
+      len -= w*h; image+= w*h; y += h;
     }
     while(len > TFT_DMA_MAX_TX_SIZE/2);
   }
 
   if (len > 0)
   {
-    ret = setAddrWindowDMA(x, y, dw, dh);
+    ret = setAddrWindowDMA(x, y, w, h);
     assert(ret == ESP_OK);
     ret = esp_lcd_panel_io_tx_color(lcd_io_handle, TFT_RAMWR, image, len*2);
   }

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -628,7 +628,7 @@ bool TFT_eSPI::dmaBusy(void)
   return true;
 
 #elif defined(ESP32_DMA_PARALLEL)
-  return true;
+  return false;
 #endif
 }
 
@@ -640,7 +640,6 @@ bool TFT_eSPI::dmaBusy(void)
 void TFT_eSPI::dmaWait(void)
 {
 #if defined(ESP32_DMA)
-
   if (!DMA_Enabled || !spiBusyCheck) return;
   spi_transaction_t *rtrans;
   esp_err_t ret;
@@ -650,9 +649,6 @@ void TFT_eSPI::dmaWait(void)
     assert(ret == ESP_OK);
   }
   spiBusyCheck = 0;
-
-#elif defined(ESP32_DMA_PARALLEL)
-  
 #endif
 }
 
@@ -864,7 +860,9 @@ extern "C" void dma_end_callback();
 
 void IRAM_ATTR dma_end_callback(spi_transaction_t *spi_tx)
 {
+#if defined(ESP32_DMA)
   WRITE_PERI_REG(SPI_DMA_CONF_REG(spi_host), 0);
+#endif
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -126,7 +126,9 @@ SPI3_HOST = 2
     #define SET_BUS_READ_MODE
 #endif
 
+////////////////////////////////////////////////////////////////////////////////////////
 // DMA checks
+////////////////////////////////////////////////////////////////////////////////////////
 
 // Enable DMA on supported setups
 #if !defined(SPI_18BIT_DRIVER)
@@ -139,6 +141,20 @@ SPI3_HOST = 2
   #define DMA_BUSY_CHECK  dmaWait()
 #else
   #define DMA_BUSY_CHECK
+#endif
+
+#ifdef ESP32_DMA_PARALLEL
+  #ifndef TFT_DMA_FREQUENCY
+    #define TFT_DMA_FREQUENCY 10000000
+  #endif
+
+  #ifndef TFT_DMA_MAX_TX_SIZE
+    #define TFT_DMA_MAX_TX_SIZE 65536 // 64 kBytes
+  #endif
+
+  #ifndef TFT_DMA_SWAP_BYTES
+    #define TFT_DMA_SWAP_BYTES 1
+  #endif
 #endif
 
 #if defined(TFT_PARALLEL_8_BIT)

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -107,7 +107,7 @@ SPI3_HOST = 2
 #endif
 
 #if !defined(DISABLE_ALL_LIBRARY_WARNINGS) && defined (ESP32_PARALLEL)
- #warning >>>>------>> DMA is not supported in parallel mode
+ #warning >>>>------>> DMA in parallel mode is in EXPERIMENTAL state! Things may break
 #endif
 
 // Processor specific code used by SPI bus transaction startWrite and endWrite functions
@@ -130,9 +130,15 @@ SPI3_HOST = 2
     #define SET_BUS_READ_MODE
 #endif
 
+// DMA checks
+
 // Code to check if DMA is busy, used by SPI bus transaction transaction and endWrite functions
-#if !defined(TFT_PARALLEL_8_BIT) && !defined(SPI_18BIT_DRIVER)
-  #define ESP32_DMA
+#if !defined(SPI_18BIT_DRIVER)
+  #if defined(TFT_PARALLEL_8_BIT)
+    #define ESP32_DMA_PARALLEL
+  #else
+    #define ESP32_DMA
+  #endif
   // Code to check if DMA is busy, used by SPI DMA + transaction + endWrite functions
   #define DMA_BUSY_CHECK  dmaWait()
 #else

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -106,10 +106,6 @@ SPI3_HOST = 2
   #endif
 #endif
 
-#if !defined(DISABLE_ALL_LIBRARY_WARNINGS) && defined (ESP32_PARALLEL)
- #warning >>>>------>> DMA in parallel mode is in EXPERIMENTAL state! Things may break
-#endif
-
 // Processor specific code used by SPI bus transaction startWrite and endWrite functions
 #if !defined (ESP32_PARALLEL)
   #define _spi_cmd       (volatile uint32_t*)(SPI_CMD_REG(SPI_PORT))
@@ -132,7 +128,7 @@ SPI3_HOST = 2
 
 // DMA checks
 
-// Code to check if DMA is busy, used by SPI bus transaction transaction and endWrite functions
+// Enable DMA on supported setups
 #if !defined(SPI_18BIT_DRIVER)
   #if defined(TFT_PARALLEL_8_BIT)
     #define ESP32_DMA_PARALLEL
@@ -149,6 +145,10 @@ SPI3_HOST = 2
   #define SPI_BUSY_CHECK
 #else
   #define SPI_BUSY_CHECK while (*_spi_cmd&SPI_USR)
+#endif
+
+#if !defined(DISABLE_ALL_LIBRARY_WARNINGS) && defined (ESP32_DMA_PARALLEL)
+  #warning >>>>------>> DMA in parallel mode is in EXPERIMENTAL state! Things may break
 #endif
 
 // If smooth font is used then it is likely SPIFFS will be needed

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -327,6 +327,10 @@
 
     #define TFT_DMA_MAX_TX_SIZE CONFIG_DMA_MAX_TX_SIZE
 
+    #ifdef CONFIG_DMA_FAST_TRANSFER
+        #define TFT_DMA_FAST_TRANSFER
+    #endif
+
     #ifdef CONFIG_DMA_SWAP_BYTES
         #define TFT_DMA_SWAP_BYTES 1
     #else

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -12,7 +12,7 @@
  * @author Ricard Bitriá Ribes (https://github.com/dracir9)
  * Created Date: 22-01-2022
  * -----
- * Last Modified: 25-02-2023
+ * Last Modified: 22-08-2023
  * Modified By: Ricard Bitriá Ribes
  * -----
  * @copyright (c) 2022 Ricard Bitriá Ribes
@@ -315,6 +315,23 @@
     #endif
 
     #define SPI_TOUCH_FREQUENCY CONFIG_SPI_TOUCH_FREQUENCY
+#endif
+
+/***************************************************************************************
+**                         Section 6: Parallel DMA configuration
+***************************************************************************************/
+
+#ifdef CONFIG_TFT_PARALLEL_8_BIT
+    
+    #define TFT_DMA_FREQUENCY CONFIG_DMA_FREQUENCY
+
+    #define TFT_DMA_MAX_TX_SIZE CONFIG_DMA_MAX_TX_SIZE
+
+    #ifdef CONFIG_DMA_SWAP_BYTES
+        #define TFT_DMA_SWAP_BYTES 1
+    #else
+        #define TFT_DMA_SWAP_BYTES 0
+    #endif
 #endif
 
 #endif // TFT_CONFIG_H

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -67,6 +67,8 @@
 
 #if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
   #include <SPI.h>
+#elif defined(TFT_PARALLEL_8_BIT)
+  #include "esp_lcd_panel_io.h"
 #endif
 
 /***************************************************************************************

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -22,21 +22,14 @@
 // Bit 0 set: viewport capability
 #define TFT_ESPI_FEATURES 1
 
-/***************************************************************************************
-**                         Section 1: Load required header files
-***************************************************************************************/
-
-//Standard support
+// Common includes
 #include <Arduino.h>
 #include <Print.h>
-#if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
-  #include <SPI.h>
-#endif
+
 /***************************************************************************************
-**                         Section 2: Load library and processor specific header files
+**                         Section 1: Load User configuration
 ***************************************************************************************/
-// Include header file that defines the fonts loaded, the TFT drivers
-// available and the pins to be used, etc, etc
+// Include file that converts from ESP_IDF configuration to library defines
 #ifdef CONFIG_TFT_eSPI_ESPIDF
   #include "TFT_config.h"
 #endif
@@ -67,6 +60,18 @@
 #endif
 
 #include <User_Setup_Select.h>
+
+/***************************************************************************************
+**                         Section 2: Additional specific includes
+***************************************************************************************/
+
+#if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
+  #include <SPI.h>
+#endif
+
+/***************************************************************************************
+**                         Section 3: Load library and processor specific header files
+***************************************************************************************/
 
 // Handle FLASH based storage e.g. PROGMEM
 #if defined(ARDUINO_ARCH_RP2040)
@@ -111,7 +116,7 @@
 #endif
 
 /***************************************************************************************
-**                         Section 3: Interface setup
+**                         Section 4: Interface setup
 ***************************************************************************************/
 #ifndef TAB_COLOUR
   #define TAB_COLOUR 0
@@ -157,7 +162,7 @@
 #endif  
 
 /***************************************************************************************
-**                         Section 4: Setup fonts
+**                         Section 5: Setup fonts
 ***************************************************************************************/
 // Use GLCD font in error case where user requests a smooth font file
 // that does not exist (this is a temporary fix to stop ESP32 reboot)
@@ -279,7 +284,7 @@ const PROGMEM fontinfo fontdata [] = {
 };
 
 /***************************************************************************************
-**                         Section 5: Font datum enumeration
+**                         Section 6: Font datum enumeration
 ***************************************************************************************/
 //These enumerate the text plotting alignment (reference datum point)
 #define TL_DATUM 0 // Top left (default)
@@ -299,7 +304,7 @@ const PROGMEM fontinfo fontdata [] = {
 #define R_BASELINE 11 // Right character baseline
 
 /***************************************************************************************
-**                         Section 6: Colour enumeration
+**                         Section 7: Colour enumeration
 ***************************************************************************************/
 // Default color definitions
 #define TFT_BLACK       0x0000      /*   0,   0,   0 */
@@ -353,7 +358,7 @@ static const uint16_t default_4bit_palette[] PROGMEM = {
 };
 
 /***************************************************************************************
-**                         Section 7: Diagnostic support
+**                         Section 8: Diagnostic support
 ***************************************************************************************/
 // #define TFT_eSPI_DEBUG     // Switch on debug support serial messages  (not used yet)
 // #define TFT_eSPI_FNx_DEBUG // Switch on debug support for function "x" (not used yet)
@@ -417,7 +422,7 @@ int16_t tch_spi_freq;// Touch controller read/write SPI frequency
 } setup_t;
 
 /***************************************************************************************
-**                         Section 8: Class member and support functions
+**                         Section 9: Class member and support functions
 ***************************************************************************************/
 
 // Callback prototype for smooth font pixel colour read
@@ -819,7 +824,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   void     setAttribute(uint8_t id = 0, uint8_t a = 0); // Set attribute value
   uint8_t  getAttribute(uint8_t id = 0);                // Get attribute value
 
-           // Used for diagnostic sketch to see library setup adopted by compiler, see Section 7 above
+           // Used for diagnostic sketch to see library setup adopted by compiler, see Section 8 above
   void     getSetup(setup_t& tft_settings); // Sketch provides the instance to populate
   bool     verifySetupID(uint32_t id);
 
@@ -961,7 +966,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
 #endif
 
 /***************************************************************************************
-**                         Section 9: TFT_eSPI class conditional extensions
+**                         Section 10: TFT_eSPI class conditional extensions
 ***************************************************************************************/
 // Load the Touch extension
 #ifdef TOUCH_CS
@@ -990,7 +995,7 @@ template <typename T> static inline void
 transpose(T& a, T& b) { T t = a; a = b; b = t; }
 
 /***************************************************************************************
-**                         Section 10: Additional extension classes
+**                         Section 11: Additional extension classes
 ***************************************************************************************/
 // Load the Button Class
 #include "Extensions/Button.h"

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -402,7 +402,7 @@
 
 // #define TFT_DMA_FREQUENCY 80000000
 #define TFT_DMA_FREQUENCY 40000000
-// #define TFT_DMA_FREQUENCY 40000000
+// #define TFT_DMA_FREQUENCY 20000000
 
 
 /**
@@ -414,9 +414,34 @@
  * for every 4095 Bytes of maximum transfer size)
  */
 
-// #define TFT_DMA_MAX_TX_SIZE 65536 // 64 kBytes
+#define TFT_DMA_MAX_TX_SIZE 65536 // 64 kBytes
 // #define TFT_DMA_MAX_TX_SIZE 153600 // 150 kBytes. Can hold a single 320*240 frame buffer with 16-bit colors
-#define TFT_DMA_MAX_TX_SIZE 307200 // 300 kBytes. Can hold a single 480*320 frame buffer with 16-bit colors
+// #define TFT_DMA_MAX_TX_SIZE 307200 // 300 kBytes. Can hold a single 480*320 frame buffer with 16-bit colors
+
+/**
+ * DMA transfer optimization for small maximum transfer size (See above)
+ * 
+ * By enabling this setting the TFT_DMA_MAX_TX_SIZE can be significantly reduced while mantaining
+ * the same level of performance. As a result the overall memory usage is lower
+ *
+ * MORE TESTING NEEEDED!!!
+ * 
+ * When transfering data using DMA that exceeds TFT_DMA_MAX_TX_SIZE we have to
+ * wait for the current transaction to complete. If this setting is disabled the
+ * transferred image is divided in smaller rectangles that fit in a single DMA operation
+ * This requires updating the display address window for each block.
+ * 
+ * Some displays allow to pause pixel data transfers and resume them later if no
+ * commands have been sent in between. Therefore we could set the address window once
+ * and send color data in multiple transfers.
+ * 
+ * NOTE: Even if the display supports it there may be project configurations or user code that
+ * interferes with this optimization. The result is that only the first transfer is valid
+ * and the following ones are ignored. As a consequence only a portion of the total buffer
+ * is displayed
+ */
+
+// #define TFT_DMA_FAST_TRANSFER
 
 /**
  * Swap byte order when sending color data. This produces the same effect as calling

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -387,3 +387,42 @@
 // so changing it here has no effect
 
 // #define SUPPORT_TRANSACTIONS
+
+// ##################################################################################
+//
+// ESP32-S2 and ESP32-S3 specific settings for Parallel DMA
+//
+// ##################################################################################
+
+/**
+ * Data transfer frequency
+ * Theoretical maximum frequency for 8-bit parallel bus is 80 MHz. Use lower values if
+ * visual glitches apperar or the module crashes or hangs frequently
+ */
+
+// #define TFT_DMA_FREQUENCY 80000000
+#define TFT_DMA_FREQUENCY 40000000
+// #define TFT_DMA_FREQUENCY 40000000
+
+
+/**
+ * Maximum number of bytes that can be transferred in a single DMA operation. This is the
+ * largest block of data that can be sent using pushImageDMA or pushPixelsDMA without
+ * blocking code execution.
+ * 
+ * Large transfer sizes require more memory for internal DMA data structures (12 Bytes
+ * for every 4095 Bytes of maximum transfer size)
+ */
+
+// #define TFT_DMA_MAX_TX_SIZE 65536 // 64 kBytes
+// #define TFT_DMA_MAX_TX_SIZE 153600 // 150 kBytes. Can hold a single 320*240 frame buffer with 16-bit colors
+#define TFT_DMA_MAX_TX_SIZE 307200 // 300 kBytes. Can hold a single 480*320 frame buffer with 16-bit colors
+
+/**
+ * Swap byte order when sending color data. This produces the same effect as calling
+ * setSwapBytes but the operation is handled by hardware rather than software which
+ * increases performance.
+ */
+
+// #define TFT_DMA_SWAP_BYTES 0    // false
+#define TFT_DMA_SWAP_BYTES 1    // true

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -143,6 +143,8 @@
 
 //#include <User_Setups/Setup301_BW16_ST7735.h>            // Setup file for Bw16-based boards with ST7735 160 x 80 TFT
 
+// #include <User_Setups/Setup350_S3_ILI9488_parallel_DMA.h>   // For the ESP32 S3 with ILI9488 in 8-bit parallel bus and DMA
+
 //#include <User_Setups/SetupX_Template.h>     // Template file for a setup
 
 

--- a/User_Setups/Setup350_S3_ILI9488_parallel_DMA.h
+++ b/User_Setups/Setup350_S3_ILI9488_parallel_DMA.h
@@ -1,0 +1,41 @@
+// See SetupX_Template.h for all options available
+#define USER_SETUP_ID 16
+
+#define TFT_PARALLEL_8_BIT
+
+#define ILI9488_DRIVER
+
+// ESP32 S3 pins used for the parallel interface TFT
+#define TFT_CS   13
+#define TFT_DC   12  // Data Command control pin - must use a GPIO in the range 0-31
+#define TFT_RST  9
+
+#define TFT_WR   11  // Write strobe control pin - must use a GPIO in the range 0-31
+#define TFT_RD   10
+
+#define TFT_D0   3  // Must use GPIO in the range 0-31 for the data bus
+#define TFT_D1   8  // so a single register write sets/clears all bits
+#define TFT_D2   16
+#define TFT_D3   15
+#define TFT_D4   7
+#define TFT_D5   6
+#define TFT_D6   5
+#define TFT_D7   4
+
+#define TFT_BL   46
+#define TFT_BACKLIGHT_ON 1
+
+// DMA Config
+#define TFT_DMA_FREQUENCY 25000000
+#define TFT_DMA_MAX_TX_SIZE 65536
+#define TFT_DMA_FAST_TRANSFER
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -364,3 +364,67 @@
 // so changing it here has no effect
 
 // #define SUPPORT_TRANSACTIONS
+
+// ##################################################################################
+//
+// ESP32-S2 and ESP32-S3 specific settings for Parallel DMA
+//
+// ##################################################################################
+
+/**
+ * Data transfer frequency
+ * Theoretical maximum frequency for 8-bit parallel bus is 80 MHz. Use lower values if
+ * visual glitches apperar or the module crashes or hangs frequently
+ */
+
+// #define TFT_DMA_FREQUENCY 80000000
+#define TFT_DMA_FREQUENCY 40000000
+// #define TFT_DMA_FREQUENCY 20000000
+
+
+/**
+ * Maximum number of bytes that can be transferred in a single DMA operation. This is the
+ * largest block of data that can be sent using pushImageDMA or pushPixelsDMA without
+ * blocking code execution.
+ * 
+ * Large transfer sizes require more memory for internal DMA data structures (12 Bytes
+ * for every 4095 Bytes of maximum transfer size)
+ */
+
+#define TFT_DMA_MAX_TX_SIZE 65536 // 64 kBytes
+// #define TFT_DMA_MAX_TX_SIZE 153600 // 150 kBytes. Can hold a single 320*240 frame buffer with 16-bit colors
+// #define TFT_DMA_MAX_TX_SIZE 307200 // 300 kBytes. Can hold a single 480*320 frame buffer with 16-bit colors
+
+/**
+ * DMA transfer optimization for small maximum transfer size (See above)
+ * 
+ * By enabling this setting the TFT_DMA_MAX_TX_SIZE can be significantly reduced while mantaining
+ * the same level of performance. As a result the overall memory usage is lower
+ *
+ * MORE TESTING NEEEDED!!!
+ * 
+ * When transfering data using DMA that exceeds TFT_DMA_MAX_TX_SIZE we have to
+ * wait for the current transaction to complete. If this setting is disabled the
+ * transferred image is divided in smaller rectangles that fit in a single DMA operation
+ * This requires updating the display address window for each block.
+ * 
+ * Some displays allow to pause pixel data transfers and resume them later if no
+ * commands have been sent in between. Therefore we could set the address window once
+ * and send color data in multiple transfers.
+ * 
+ * NOTE: Even if the display supports it there may be project configurations or user code that
+ * interferes with this optimization. The result is that only the first transfer is valid
+ * and the following ones are ignored. As a consequence only a portion of the total buffer
+ * is displayed
+ */
+
+// #define TFT_DMA_FAST_TRANSFER
+
+/**
+ * Swap byte order when sending color data. This produces the same effect as calling
+ * setSwapBytes but the operation is handled by hardware rather than software which
+ * increases performance.
+ */
+
+// #define TFT_DMA_SWAP_BYTES 0    // false
+#define TFT_DMA_SWAP_BYTES 1    // true


### PR DESCRIPTION
Added support for DMA transfers with 8-bit parallel bus.

Tested with ESP32-S3 and ILI9488 using Arduino IDE, PlatformIO and ESP-IDF. It should work with ESP32-S2 as well. All other displays using 8-bit bus should also be compatible unless they use a completely different protocol.

More testing is probably needed but I don't have more displays at my disposal.

LIMITATIONS: Using DMA with a parallel bus implies that all the bus GPIO are handled by hardware. Therefore, once DMA is started by calling initDMA() DO NOT use any non-DMA functions that write to the display until deInitDMA() function is called. Otherwise, it will cause undefined behaviour.