### PR TITLE
Allow custom function to write CS&DC to minimize the GPIO usage.

### DIFF
--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -145,8 +145,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write

--- a/Processors/TFT_eSPI_ESP32_C3.h
+++ b/Processors/TFT_eSPI_ESP32_C3.h
@@ -136,8 +136,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -159,8 +159,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write

--- a/Processors/TFT_eSPI_ESP8266.h
+++ b/Processors/TFT_eSPI_ESP8266.h
@@ -48,8 +48,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #if (TFT_DC == 16)
     #define DC_C digitalWrite(TFT_DC, LOW)

--- a/Processors/TFT_eSPI_Generic.h
+++ b/Processors/TFT_eSPI_Generic.h
@@ -40,8 +40,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #define DC_C digitalWrite(TFT_DC, LOW)
   #define DC_D digitalWrite(TFT_DC, HIGH)

--- a/Processors/TFT_eSPI_RP2040.h
+++ b/Processors/TFT_eSPI_RP2040.h
@@ -146,8 +146,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
 #else
   #if !defined (RP2040_PIO_INTERFACE)// SPI
     //#define DC_C sio_hw->gpio_clr = (1ul << TFT_DC)

--- a/Processors/TFT_eSPI_STM32.h
+++ b/Processors/TFT_eSPI_STM32.h
@@ -218,8 +218,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #if !defined (TFT_DC) || (TFT_DC < 0)
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C if (write_dc) write_dc(LOW)
+  #define DC_D if (write_dc) write_dc(HIGH)
   #undef  TFT_DC
 #else
   // Convert Arduino pin reference Dn or STM pin reference PXn to port and mask

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -603,7 +603,11 @@ void TFT_eSPI::begin(uint8_t tc)
  init(tc);
 }
 
-
+void TFT_eSPI::init(void (*write_dc)(uint8_t val), uint8_t tc)
+{
+  this->write_dc = write_dc;
+  init(tc);
+}
 /***************************************************************************************
 ** Function name:           init (tc is tab colour for ST7735 displays only)
 ** Description:             Reset, then initialise the TFT display registers

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -434,6 +434,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   // init() and begin() are equivalent, begin() included for backwards compatibility
   // Sketch defined tab colour option is for ST7735 displays only
   void     init(uint8_t tc = TAB_COLOUR), begin(uint8_t tc = TAB_COLOUR);
+  void     init(void (*write_dc)(uint8_t val), uint8_t tc = TAB_COLOUR);
 
   // These are virtual so the TFT_eSprite class can override them with sprite specific functions
   virtual void     drawPixel(int32_t x, int32_t y, uint32_t color),
@@ -837,6 +838,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
 
  //--------------------------------------- private ------------------------------------//
  private:
+  void (*write_dc)(uint8_t val);
            // Legacy begin and end prototypes - deprecated TODO: delete
   void     spi_begin();
   void     spi_end();


### PR DESCRIPTION
This pull request is based on version 2.2.3, because I define `DC_C` and `DC_D` to call custom function if `TFT_DC` is not defined. 

It's ok in v2.2.3, because only `TFT_eSPI.cpp` uses `DC_C` or `DC_D`.

I am not able to make it compile in latest version, because `TFT_eSPI_ESP32.c` also depends on `DC_C` and `DC_D`, I don't know how to call custom function in it.

Would you help me make it work in latest version?