### PR TITLE
Allow Custom Function to Write CS & DC to Minimize GPIO Usage

### DIFF
--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -58,8 +58,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     #define DC_C GPIO.out_w1tc = (1 << TFT_DC)
@@ -100,8 +100,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     #if TFT_CS >= 32

--- a/Processors/TFT_eSPI_ESP8266.h
+++ b/Processors/TFT_eSPI_ESP8266.h
@@ -48,8 +48,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if (TFT_DC == 16)
     #define DC_C digitalWrite(TFT_DC, LOW)
@@ -64,8 +64,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if (TFT_CS == 16)
     #define CS_L digitalWrite(TFT_CS, LOW)

--- a/Processors/TFT_eSPI_Generic.h
+++ b/Processors/TFT_eSPI_Generic.h
@@ -40,8 +40,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #define DC_C digitalWrite(TFT_DC, LOW)
   #define DC_D digitalWrite(TFT_DC, HIGH)
@@ -51,8 +51,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #define CS_L digitalWrite(TFT_CS, LOW)
   #define CS_H digitalWrite(TFT_CS, HIGH)

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -262,6 +262,12 @@ void TFT_eSPI::begin(uint8_t tc)
  init(tc);
 }
 
+void TFT_eSPI::init(void (*write_dc)(uint8_t val), void (*write_cs)(uint8_t val), uint8_t tc)
+{
+  this->write_dc = write_dc;
+  this->write_cs = write_cs;
+  init(tc);
+}
 
 /***************************************************************************************
 ** Function name:           init (tc is tab colour for ST7735 displays only)

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -363,6 +363,7 @@ class TFT_eSPI : public Print {
   // init() and begin() are equivalent, begin() included for backwards compatibility
   // Sketch defined tab colour option is for ST7735 displays only
   void     init(uint8_t tc = TAB_COLOUR), begin(uint8_t tc = TAB_COLOUR);
+  void     init(void (*write_dc)(uint8_t val), void (*write_cs)(uint8_t val), uint8_t tc = TAB_COLOUR);
 
   // These are virtual so the TFT_eSprite class can override them with sprite specific functions
   virtual void     drawPixel(int32_t x, int32_t y, uint32_t color),
@@ -661,6 +662,8 @@ class TFT_eSPI : public Print {
 
  //--------------------------------------- private ------------------------------------//
  private:
+  void     (*write_dc)(uint8_t val);
+  void     (*write_cs)(uint8_t val);
            // Legacy begin and end prototypes - deprecated TODO: delete
   void     spi_begin();
   void     spi_end();


### PR DESCRIPTION
This pull request introduces modifications that originated from version 2.2.3. The key changes include the definitions of `DC_C` and `DC_D` which are utilized to invoke custom functions when `TFT_DC` is not predefined.

In version 2.2.3, this implementation was seamless as `DC_C` and `DC_D` were exclusively used in `TFT_eSPI.cpp`. However, I've encountered compilation challenges with the latest version of the codebase. The reason for this difficulty is that `TFT_eSPI_ESP32.c` now also relies on `DC_C` and `DC_D`. The current structure does not support the incorporation of custom functions in this context.

I am seeking assistance to adapt these modifications, ensuring compatibility with the latest version. Any guidance or suggestions on how to effectively integrate custom functions within `TFT_eSPI_ESP32.c` would be greatly appreciated.

