### PR TITLE
Allow Custom Function to Write CS & DC to Minimize GPIO Usage

### DIFF
--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -631,7 +631,7 @@ void TFT_eSPI::pushPixelsDMA(uint16_t* image, uint32_t len)
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = image;  //finally send the line data
   trans.length = len * 16;        //Data length, in bits
   trans.flags = 0;                //SPI_TRANS_USE_TXDATA flag
@@ -663,7 +663,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = image;   //Data pointer
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -739,7 +739,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = buffer;  //finally send the line data
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -763,8 +763,16 @@ extern "C" void dc_callback();
 
 void IRAM_ATTR dc_callback(spi_transaction_t *spi_tx)
 {
-  if ((bool)spi_tx->user) {DC_D;}
+  // check if ptr flag is set
+  uintptr_t flag = CHECK_PTR_FLAG(spi_tx->user);
+#ifndef TFT_DC
+  TFT_eSPI* this_ptr = (TFT_eSPI*) CLEAR_PTR_FLAG(spi_tx->user);
+  if ((bool)flag) {this_ptr->DC_D;}
+  else {this_ptr->DC_C;}
+#else
+  if ((bool)flag) {DC_D;}
   else {DC_C;}
+#endif
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -145,8 +145,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write
@@ -201,8 +201,8 @@ SPI3_HOST = 2
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
   #define TFT_CS -1  // Keep DMA code happy
-  #define CS_L       // No macro allocated so it generates no code
-  #define CS_H       // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     #if TFT_CS >= 32

--- a/Processors/TFT_eSPI_ESP32_C3.c
+++ b/Processors/TFT_eSPI_ESP32_C3.c
@@ -655,7 +655,7 @@ void TFT_eSPI::pushPixelsDMA(uint16_t* image, uint32_t len)
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = image;  //finally send the line data
   trans.length = len * 16;        //Data length, in bits
   trans.flags = 0;                //SPI_TRANS_USE_TXDATA flag
@@ -687,7 +687,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = image;   //Data pointer
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -763,7 +763,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = buffer;  //finally send the line data
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -787,8 +787,16 @@ extern "C" void dc_callback();
 
 void IRAM_ATTR dc_callback(spi_transaction_t *spi_tx)
 {
-  if ((bool)spi_tx->user) {DC_D;}
+  // check if ptr flag is set
+  uintptr_t flag = CHECK_PTR_FLAG(spi_tx->user);
+#ifndef TFT_DC
+  TFT_eSPI* this_ptr = (TFT_eSPI*) CLEAR_PTR_FLAG(spi_tx->user);
+  if ((bool)flag) {this_ptr->DC_D;}
+  else {this_ptr->DC_C;}
+#else
+  if ((bool)flag) {DC_D;}
   else {DC_C;}
+#endif
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32_C3.h
+++ b/Processors/TFT_eSPI_ESP32_C3.h
@@ -136,8 +136,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write
@@ -192,8 +192,8 @@ SPI3_HOST = 2
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
   #define TFT_CS -1  // Keep DMA code happy
-  #define CS_L       // No macro allocated so it generates no code
-  #define CS_H       // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     #if TFT_CS >= 32

--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -657,7 +657,7 @@ void TFT_eSPI::pushPixelsDMA(uint16_t* image, uint32_t len)
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = image;  //finally send the line data
   trans.length = len * 16;        //Data length, in bits
   trans.flags = 0;                //SPI_TRANS_USE_TXDATA flag
@@ -701,7 +701,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = buffer;   //Data pointer
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -789,7 +789,7 @@ void TFT_eSPI::pushImageDMA(int32_t x, int32_t y, int32_t w, int32_t h, uint16_t
 
   memset(&trans, 0, sizeof(spi_transaction_t));
 
-  trans.user = (void *)1;
+  trans.user = SET_PTR_FLAG(this);
   trans.tx_buffer = buffer;  //finally send the line data
   trans.length = len * 16;   //Data length, in bits
   trans.flags = 0;           //SPI_TRANS_USE_TXDATA flag
@@ -813,8 +813,16 @@ extern "C" void dc_callback();
 
 void IRAM_ATTR dc_callback(spi_transaction_t *spi_tx)
 {
-  if ((bool)spi_tx->user) {DC_D;}
+  // check if ptr flag is set
+  uintptr_t flag = CHECK_PTR_FLAG(spi_tx->user);
+#ifndef TFT_DC
+  TFT_eSPI* this_ptr = (TFT_eSPI*) CLEAR_PTR_FLAG(spi_tx->user);
+  if ((bool)flag) {this_ptr->DC_D;}
+  else {this_ptr->DC_C;}
+#else
+  if ((bool)flag) {DC_D;}
   else {DC_C;}
+#endif
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -159,8 +159,8 @@ SPI3_HOST = 2
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     // TFT_DC, by design, must be in range 0-31 for single register parallel write
@@ -215,8 +215,8 @@ SPI3_HOST = 2
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
   #define TFT_CS -1  // Keep DMA code happy
-  #define CS_L       // No macro allocated so it generates no code
-  #define CS_H       // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if defined (TFT_PARALLEL_8_BIT)
     #if TFT_CS >= 32

--- a/Processors/TFT_eSPI_ESP8266.h
+++ b/Processors/TFT_eSPI_ESP8266.h
@@ -48,8 +48,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if (TFT_DC == 16)
     #define DC_C digitalWrite(TFT_DC, LOW)
@@ -64,8 +64,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if (TFT_CS == 16)
     #define CS_L digitalWrite(TFT_CS, LOW)

--- a/Processors/TFT_eSPI_Generic.h
+++ b/Processors/TFT_eSPI_Generic.h
@@ -40,8 +40,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #define DC_C digitalWrite(TFT_DC, LOW)
   #define DC_D digitalWrite(TFT_DC, HIGH)
@@ -51,8 +51,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #define CS_L digitalWrite(TFT_CS, LOW)
   #define CS_H digitalWrite(TFT_CS, HIGH)

--- a/Processors/TFT_eSPI_RP2040.h
+++ b/Processors/TFT_eSPI_RP2040.h
@@ -146,8 +146,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_DC
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
 #else
   #if !defined (RP2040_PIO_INTERFACE)// SPI
     //#define DC_C sio_hw->gpio_clr = (1ul << TFT_DC)
@@ -179,8 +179,8 @@
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #ifndef TFT_CS
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
+  #define CS_L write_cs(LOW);
+  #define CS_H write_cs(HIGH);
 #else
   #if !defined (RP2040_PIO_INTERFACE) // SPI
     #if  defined (RPI_DISPLAY_TYPE) && !defined (MHS_DISPLAY_TYPE)

--- a/Processors/TFT_eSPI_STM32.h
+++ b/Processors/TFT_eSPI_STM32.h
@@ -218,8 +218,8 @@
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
 #if !defined (TFT_DC) || (TFT_DC < 0)
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
+  #define DC_C write_dc(LOW)
+  #define DC_D write_dc(HIGH)
   #undef  TFT_DC
 #else
   // Convert Arduino pin reference Dn or STM pin reference PXn to port and mask

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -603,6 +603,12 @@ void TFT_eSPI::begin(uint8_t tc)
  init(tc);
 }
 
+void TFT_eSPI::init(void (*write_dc)(uint8_t val), void (*write_cs)(uint8_t val), uint8_t tc)
+{
+  this->write_dc = write_dc;
+  this->write_cs = write_cs;
+  init(tc);
+}
 
 /***************************************************************************************
 ** Function name:           init (tc is tab colour for ST7735 displays only)

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -420,6 +420,18 @@ int16_t tch_spi_freq;// Touch controller read/write SPI frequency
 **                         Section 8: Class member and support functions
 ***************************************************************************************/
 
+// Macro definitions for manipulating the least significant bit of a pointer
+// These macros are used to utilize the pointer's alignment property to carry an additional bit of information
+
+// Set the least significant bit of a pointer to carry extra information
+#define SET_PTR_FLAG(ptr) ((void*)((uintptr_t)(ptr) | 0x1))
+
+// Clear the least significant bit of a pointer to retrieve the original pointer
+#define CLEAR_PTR_FLAG(ptr) ((void*)((uintptr_t)(ptr) & ~((uintptr_t)0x1)))
+
+// Check if the least significant bit of a pointer is set
+#define CHECK_PTR_FLAG(ptr) (((uintptr_t)(ptr)) & 0x1)
+
 // Callback prototype for smooth font pixel colour read
 typedef uint16_t (*getColorCallback)(uint16_t x, uint16_t y);
 
@@ -836,10 +848,11 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   uint8_t  decoderState = 0;   // UTF8 decoder state        - not for user access
   uint16_t decoderBuffer;      // Unicode code-point buffer - not for user access
 
- //--------------------------------------- private ------------------------------------//
- private:
   void     (*write_dc)(uint8_t val);
   void     (*write_cs)(uint8_t val);
+
+ //--------------------------------------- private ------------------------------------//
+ private:
            // Legacy begin and end prototypes - deprecated TODO: delete
   void     spi_begin();
   void     spi_end();

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -434,6 +434,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   // init() and begin() are equivalent, begin() included for backwards compatibility
   // Sketch defined tab colour option is for ST7735 displays only
   void     init(uint8_t tc = TAB_COLOUR), begin(uint8_t tc = TAB_COLOUR);
+  void     init(void (*write_dc)(uint8_t val), void (*write_cs)(uint8_t val), uint8_t tc = TAB_COLOUR);
 
   // These are virtual so the TFT_eSprite class can override them with sprite specific functions
   virtual void     drawPixel(int32_t x, int32_t y, uint32_t color),
@@ -837,6 +838,8 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
 
  //--------------------------------------- private ------------------------------------//
  private:
+  void     (*write_dc)(uint8_t val);
+  void     (*write_cs)(uint8_t val);
            // Legacy begin and end prototypes - deprecated TODO: delete
   void     spi_begin();
   void     spi_end();


### PR DESCRIPTION
Add new init function to pass write_cs & write_dc callback, so that TFT_CS and TFT_DC can be connected to GPIO expander.