### PR TITLE
Add TouchScreen support for displays with parallel bus.

### DIFF
--- a/Extensions/Touch.cpp
+++ b/Extensions/Touch.cpp
@@ -4,7 +4,7 @@
 // Define TOUCH_CS is the user setup file to enable this code for SPI mode
 // Define TOUCH_ANALOG is the user setup file to enable this code for raw ADC mode,
 // an additional definitions for TOUCH_ANALOG_XP TOUCH_ANALOG_YM TOUCH_ANALOG_XM
-// and TOUCH_ANALOG_YP=4 is required.
+// and TOUCH_ANALOG_YP is required.
 
 // A demo is provided in examples Generic folder
 

--- a/Extensions/Touch.cpp
+++ b/Extensions/Touch.cpp
@@ -471,13 +471,6 @@ void TFT_eSPI::calibrateTouch(uint16_t *parameters, uint32_t color_fg, uint32_t 
     parameters[3] = touchCalibration_y1;
     parameters[4] = touchCalibration_rotate | (touchCalibration_invert_x <<1) | (touchCalibration_invert_y <<2);
   }
-  Serial.printf("params: x0=% 4d x1=% 4d y0=% 4d y1=% 4d flags:%02x",
-  touchCalibration_x0,
-  touchCalibration_x1,
-  touchCalibration_y0,
-  touchCalibration_y1,
-  touchCalibration_rotate | (touchCalibration_invert_x <<1) | (touchCalibration_invert_y <<2)
-  );
 }
 
 

--- a/Extensions/Touch.h
+++ b/Extensions/Touch.h
@@ -23,6 +23,7 @@
   void     setTouch(uint16_t *data);
 
  private:
+ #ifdef TOUCH_CS
            // Legacy support only - deprecated TODO: delete
   void     spi_begin_touch();
   void     spi_end_touch();
@@ -30,7 +31,7 @@
            // Handlers for the touch controller bus settings
   inline void begin_touch_read_write() __attribute__((always_inline));
   inline void end_touch_read_write()   __attribute__((always_inline));
-
+#endif
            // Private function to validate a touch, allow settle time and reduce spurious coordinates
   uint8_t  validTouch(uint16_t *x, uint16_t *y, uint16_t threshold = 600);
 

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -6133,9 +6133,10 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
 
 
 ////////////////////////////////////////////////////////////////////////////////////////
-#ifdef TOUCH_CS
+#if defined(TOUCH_CS) ||  defined(TOUCH_ANALOG)
   #include "Extensions/Touch.cpp"
 #endif
+
 
 #include "Extensions/Button.cpp"
 

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -960,10 +960,10 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
 **                         Section 9: TFT_eSPI class conditional extensions
 ***************************************************************************************/
 // Load the Touch extension
-#ifdef TOUCH_CS
-  #if defined (TFT_PARALLEL_8_BIT) || defined (RP2040_PIO_INTERFACE)
+#if defined(TOUCH_CS) || defined(TOUCH_ANALOG)
+  #if !defined(TOUCH_ANALOG) && (defined(TFT_PARALLEL_8_BIT) || defined (RP2040_PIO_INTERFACE))
     #if !defined(DISABLE_ALL_LIBRARY_WARNINGS)
-      #error >>>>------>> Touch functions not supported in 8/16-bit parallel mode or with RP2040 PIO.
+      #error >>>>------>> Touch functions not supported.
     #endif
   #else
     #include "Extensions/Touch.h"        // Loaded if TOUCH_CS is defined by user

--- a/User_Setups/Setup70i_ESP32_ILI9486_Parallel_Touch.h
+++ b/User_Setups/Setup70i_ESP32_ILI9486_Parallel_Touch.h
@@ -1,0 +1,45 @@
+// Setup for the ESP32 Wemos D1 R32 (modified) in Parallel mode with ILI9486 display and resistive touch screen
+#define USER_SETUP_ID 70
+
+#define ESP32_PARALLEL
+#define TFT_PARALLEL_8_BIT
+#define ILI9486_DRIVER
+
+#define TFT_WIDTH  320
+#define TFT_HEIGHT 480
+
+//Enable analogue touch screen reading
+#define TOUCH_ANALOG
+// Define which pins are used by touch screen
+#define TOUCH_ANALOG_XP 12
+#define TOUCH_ANALOG_YM 13
+#define TOUCH_ANALOG_XM 15
+#define TOUCH_ANALOG_YP 4
+// ESP32 WiFi removes access to ADC2 channel so pins 4 and 15 attached to the touchscreen 
+// no longer have analog input capability. So pins 35 and 39 is used as ADC1.
+#define TOUCH_ANALOG_AXM 35
+#define TOUCH_ANALOG_AYP 39
+
+#define TFT_RST 32
+#define TFT_CS 33
+#define TFT_RD 2
+#define TFT_DC 15 //muxed with X- touchscreen
+#define TFT_WR 4  //muxed with Y+ touchscreen
+#define TFT_D0 12 //muxed with X+ touchscreen
+#define TFT_D1 13 //muxed with Y- touchscreen
+#define TFT_D2 26
+#define TFT_D3 25
+#define TFT_D4 17
+#define TFT_D5 16
+#define TFT_D6 27
+#define TFT_D7 14
+
+#define LOAD_GLCD
+#define LOAD_FONT2
+#define LOAD_FONT4
+#define LOAD_FONT6
+#define LOAD_FONT7
+#define LOAD_FONT8
+#define LOAD_GFXFF
+
+#define SMOOTH_FONT


### PR DESCRIPTION
Used internal ADC for touchscreens. Config avaliable for ESP32 Wemos D1 R32 with ILI9486. Requires additional wire modification as shown on https://github.com/s60sc/Adafruit_TouchScreen repo: (https://github.com/s60sc/Adafruit_TouchScreen/raw/master/extras/wiring.jpg)