### PR TITLE
iILI9486 driver improvements

### DIFF
--- a/Processors/TFT_eSPI_ESP32.h
+++ b/Processors/TFT_eSPI_ESP32.h
@@ -227,7 +227,7 @@ SPI3_HOST = 2
         #define CS_H GPIO.out1_w1ts.val = (1 << (TFT_CS - 32))//;GPIO.out1_w1ts.val = (1 << (TFT_CS - 32))
       #endif
     #elif (TFT_CS >= 0)
-      #ifdef RPI_DISPLAY_TYPE  // RPi display needs a slower CS change
+      #if defined(RPI_DISPLAY_TYPE) || defined(ILI9486_DRIVER)  // RPi display needs a slower CS change
         #define CS_L GPIO.out_w1ts = (1 << TFT_CS); GPIO.out_w1tc = (1 << TFT_CS)
         #define CS_H GPIO.out_w1tc = (1 << TFT_CS); GPIO.out_w1ts = (1 << TFT_CS)
       #else

--- a/TFT_Drivers/ILI9486_Init.h
+++ b/TFT_Drivers/ILI9486_Init.h
@@ -6,79 +6,82 @@
 // See ST7735_Setup.h file for an alternative format
 
 {
-// From https://github.com/notro/fbtft/blob/master/fb_ili9486.c
-
     writecommand(0x01); // SW reset
     delay(120);
 
-    writecommand(0x11); // Sleep out, also SW reset
-    delay(120);
+    writecommand(0xC0);
+    writedata(0x19); // VREG1OUT POSITIVE
+    writedata(0x1a); // VREG2OUT NEGATIVE
 
-    writecommand(0x3A);
-    #if defined (TFT_PARALLEL_8_BIT) || defined (TFT_PARALLEL_16_BIT) || defined (RPI_DISPLAY_TYPE)
-      writedata(0x55);           // 16-bit colour interface
-    #else
-      writedata(0x66);           // 18-bit colour interface
-    #endif
+    writecommand(0xC1);
+    writedata(0x45); // VGH,VGL    VGH>=14V.
+    writedata(0x00);
 
-    writecommand(0xC0); //                          1100.0000 Power Control 1
-    writedata(0x0E);    //                          0001.0111   ... VRH1
-    writedata(0x0E);    //                          0001.0101   ... VRH2
-    writecommand(0xC1); //                          1100.0001 Power Control 2
-    writedata(0x41);    //                          0100.0001   . SAP BT
-    writedata(0x00);    //                          0000.0000   ..... VC
-    writecommand(0xC2); //                          1100.0010 Power Control 3
-    writedata(0x55);    //     nb. was 0x44         0101.0101   . DCA1 . DCA0
+    writecommand(0xC2); // Normal mode, increase can change the display quality, while increasing power consumption
+    writedata(0x33);
 
-    writecommand(0xC5);
+    writecommand(0XC5);
     writedata(0x00);
+    writedata(0x28); // VCM_REG[7:0]. <=0X80.
+
+    writecommand(0xB1); // Sets the frame frequency of full color normal mode
+    writedata(0xA0);    // 0XB0 =70HZ, <=0XB0.0xA0=62HZ
+    writedata(0x11);
+
+    writecommand(0xB4);
+    writedata(0x02); // 2 DOT FRAME MODE,F<=70HZ.
+
+    writecommand(0xB6); //
     writedata(0x00);
-    writedata(0x00);
-    writedata(0x00);
+    writedata(0x42); // 0 GS SS SM ISC[3:0];
+    writedata(0x3B);
+
+    writecommand(0xB7);
+    writedata(0x07);
 
     writecommand(0xE0);
+    writedata(0x1F);
+    writedata(0x25);
+    writedata(0x22);
+    writedata(0x0B);
+    writedata(0x06);
+    writedata(0x0A);
+    writedata(0x4E);
+    writedata(0xC6);
+    writedata(0x39);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x00);
+
+    writecommand(0XE1);
+    writedata(0x1F);
+    writedata(0x3F);
+    writedata(0x3F);
     writedata(0x0F);
     writedata(0x1F);
-    writedata(0x1C);
-    writedata(0x0C);
     writedata(0x0F);
-    writedata(0x08);
-    writedata(0x48);
-    writedata(0x98);
-    writedata(0x37);
-    writedata(0x0A);
-    writedata(0x13);
-    writedata(0x04);
-    writedata(0x11);
-    writedata(0x0D);
-    writedata(0x00);
- 
-    writecommand(0xE1);
-    writedata(0x0F);
-    writedata(0x32);
-    writedata(0x2E);
-    writedata(0x0B);
-    writedata(0x0D);
+    writedata(0x46);
+    writedata(0x49);
+    writedata(0x31);
     writedata(0x05);
-    writedata(0x47);
-    writedata(0x75);
-    writedata(0x37);
-    writedata(0x06);
-    writedata(0x10);
+    writedata(0x09);
     writedata(0x03);
-    writedata(0x24);
-    writedata(0x20);
+    writedata(0x1C);
+    writedata(0x1A);
     writedata(0x00);
- 
-    #if defined (TFT_PARALLEL_8_BIT) || defined (TFT_PARALLEL_16_BIT) || defined (RPI_DISPLAY_TYPE)
-      writecommand(TFT_INVOFF);
-    #else
-      writecommand(TFT_INVON);
-    #endif
- 
-    writecommand(0x36);
-    writedata(0x48);
 
-    writecommand(0x29);                     // display on
-    delay(150);
+    writecommand(0X3A); // Set Interface Pixel Format
+#ifdef SPI_18BIT_DRIVER
+    writedata(0x66);
+#else
+    writedata(0x55);
+#endif
+    delay(200);
+    writecommand(0x11); // Exit Sleep
+
+    delay(120);
+    writecommand(0x29); // Display on
 }

--- a/TFT_Drivers/ILI9486_Rotation.h
+++ b/TFT_Drivers/ILI9486_Rotation.h
@@ -1,47 +1,47 @@
-  // This is the command sequence that rotates the ILI9486 driver coordinate frame
+// This is the command sequence that rotates the ILI9486 driver coordinate frame
 
-  writecommand(TFT_MADCTL);
-  rotation = m % 8;
-  switch (rotation) {
-   case 0: // Portrait
-     writedata(TFT_MAD_BGR | TFT_MAD_MX);
-     _width  = _init_width;
-     _height = _init_height;
-     break;
-   case 1: // Landscape (Portrait + 90)
-     writedata(TFT_MAD_BGR | TFT_MAD_MV);
-     _width  = _init_height;
-     _height = _init_width;
-     break;
-   case 2: // Inverter portrait
-     writedata( TFT_MAD_BGR | TFT_MAD_MY);
-     _width  = _init_width;
-     _height = _init_height;
-    break;
-   case 3: // Inverted landscape
-     writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_MY);
-     _width  = _init_height;
-     _height = _init_width;
-     break;
-   case 4: // Portrait
-     writedata(TFT_MAD_BGR | TFT_MAD_MX | TFT_MAD_MY);
-     _width  = _init_width;
-     _height = _init_height;
-     break;
-   case 5: // Landscape (Portrait + 90)
-     writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX);
-     _width  = _init_height;
-     _height = _init_width;
-     break;
-   case 6: // Inverter portrait
-     writedata( TFT_MAD_BGR);
-     _width  = _init_width;
-     _height = _init_height;
-     break;
-   case 7: // Inverted landscape
-     writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MY);
-     _width  = _init_height;
-     _height = _init_width;
-     break;
-  }
-  
+writecommand(TFT_MADCTL);
+rotation = m % 8;
+switch (rotation)
+{
+case 0: // Portrait
+  writedata(TFT_MAD_BGR | TFT_MAD_MX | TFT_MAD_MY);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 1: // Landscape (Portrait + 90cw)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MY);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 2: // Portrait UP_DOWN (Portrait + 180cw)
+  writedata(TFT_MAD_BGR);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 3: // Landscape UP_DOWN (Portrait + 270cw)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 4: // Portrait mirrored
+  writedata(TFT_MAD_BGR | TFT_MAD_MY);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 5: // Landscape mirrored (Portrait mirrored + 90cw)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+case 6: // Portrait mirrored UP_DOWN (Portrait mirrored + 180cw)
+  writedata(TFT_MAD_BGR | TFT_MAD_MX);
+  _width = _init_width;
+  _height = _init_height;
+  break;
+case 7: // Landscape mirrored UP_DOWN (Portrait mirrored + 270cw)
+  writedata(TFT_MAD_BGR | TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_MY);
+  _width = _init_height;
+  _height = _init_width;
+  break;
+}


### PR DESCRIPTION
* refactored initialization procedure. Avoiding inversion to keep RGB color schema
* For CS line RPI approach used, as it require more stable CS line switching
* TFT_eSPI::setWindow refactored
* TFT_eSPI::writecommand(uint8_t c) refactored for this driver

Driver datasheet https://www.waveshare.com/w/upload/7/78/ILI9486_Datasheet.pdf

This PR is a result of my work to launch [WaveShare 4inch Touch LCD Shield for Arduino (SKU:13587)](https://www.waveshare.com/4inch-tft-touch-shield.htm) display with Wemos D1 R32 board.

Most significant change is a way how commands and are sent to screen. For some reason `tft_Write_32C` does not produce true 32 bit data, so I had to use sequence of 8 bit functions.

Another issue I faced with - was that CS line require longer timings like it is done for RPI version of code.

And last this which was refactored - initialization and rotation routines. Most significant change is related to color inversion, to keep RGB scheme.