### PR TITLE
Cube mx

### DIFF
--- a/Processors/TFT_eSPI_STM32.c
+++ b/Processors/TFT_eSPI_STM32.c
@@ -202,7 +202,8 @@ void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
 #endif
 }
 
-
+// We dont need this. CubeMX will create code for setting the gpiomode.
+#ifndef CONFIG_TFT_eSPI_STM32CUBE
 /***************************************************************************************
 ** Function name:           GPIO direction control  - supports class functions
 ** Description:             Set STM32 GPIO pin to input or output (set high) ASAP
@@ -215,6 +216,7 @@ void TFT_eSPI::gpioMode(uint8_t gpio, uint8_t mode)
   // Input with pullup
   else pin_function(pn, STM_PIN_DATA(STM_MODE_INPUT, GPIO_PULLUP, 0));
 }
+#endif
 
 /***************************************************************************************############# UNTESTED ###################
 ** Function name:           read byte  - supports class functions

--- a/Processors/TFT_eSPI_STM32.h
+++ b/Processors/TFT_eSPI_STM32.h
@@ -10,6 +10,12 @@
 
 // Include processor specific header
 // None
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #include "main.h"
+  #include <WString.h>
+  #include <math.h>
+  #include <itoa.h>
+#endif
 
 // RPi support not tested - Fast RPi not supported
 
@@ -226,78 +232,150 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 // Define the DC (TFT Data/Command or Register Select (RS))pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
-#if !defined (TFT_DC) || (TFT_DC < 0)
-  #define DC_C // No macro allocated so it generates no code
-  #define DC_D // No macro allocated so it generates no code
-  #undef  TFT_DC
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if !defined (TFT_DC_Pin) || (TFT_DC_Pin < 0)
+    #define DC_C // No macro allocated so it generates no code
+    #define DC_D // No macro allocated so it generates no code
+    #undef  TFT_DC
+  #else
+    // Convert Arduino pin reference Dn or STM pin reference PXn to port and mask
+    #define DC_PORT     TFT_DC_GPIO_Port
+    #define DC_PIN_MASK TFT_DC_Pin
+    // Use bit set reset register
+    #define DC_C DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK<<16
+    #define DC_D DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK
+  #endif
 #else
-  // Convert Arduino pin reference Dn or STM pin reference PXn to port and mask
-  #define DC_PORT     digitalPinToPort(TFT_DC)
-  #define DC_PIN_MASK digitalPinToBitMask(TFT_DC)
-  // Use bit set reset register
-  #define DC_C DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK<<16
-  #define DC_D DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK
+  #if !defined (TFT_DC) || (TFT_DC < 0)
+    #define DC_C // No macro allocated so it generates no code
+    #define DC_D // No macro allocated so it generates no code
+    #undef  TFT_DC
+  #else
+    // Convert Arduino pin reference Dn or STM pin reference PXn to port and mask
+    #define DC_PORT     digitalPinToPort(TFT_DC)
+    #define DC_PIN_MASK digitalPinToBitMask(TFT_DC)
+    // Use bit set reset register
+    #define DC_C DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK<<16
+    #define DC_D DC_DELAY; DC_PORT->BSRR = DC_PIN_MASK
+  #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Define the CS (TFT chip select) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
-#if !defined (TFT_CS) || (TFT_CS < 0)
-  #define CS_L // No macro allocated so it generates no code
-  #define CS_H // No macro allocated so it generates no code
-  #undef  TFT_CS
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if !defined (TFT_CS_Pin) || (TFT_CS_Pin < 0)
+    #define CS_L // No macro allocated so it generates no code
+    #define CS_H // No macro allocated so it generates no code
+    #undef  TFT_CS
+  #else
+    // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+    #define CS_PORT      TFT_CS_GPIO_Port
+    #define CS_PIN_MASK  TFT_CS_Pin
+    // Use bit set reset register
+    #define CS_L CS_PORT->BSRR = CS_PIN_MASK<<16
+    #define CS_H CS_PORT->BSRR = CS_PIN_MASK
+  #endif
 #else
-  // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
-  #define CS_PORT      digitalPinToPort(TFT_CS)
-  #define CS_PIN_MASK  digitalPinToBitMask(TFT_CS)
-  // Use bit set reset register
-  #define CS_L CS_PORT->BSRR = CS_PIN_MASK<<16
-  #define CS_H CS_PORT->BSRR = CS_PIN_MASK
+  #if !defined (TFT_CS) || (TFT_CS < 0)
+    #define CS_L // No macro allocated so it generates no code
+    #define CS_H // No macro allocated so it generates no code
+    #undef  TFT_CS
+  #else
+    // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+    #define CS_PORT      digitalPinToPort(TFT_CS)
+    #define CS_PIN_MASK  digitalPinToBitMask(TFT_CS)
+    // Use bit set reset register
+    #define CS_L CS_PORT->BSRR = CS_PIN_MASK<<16
+    #define CS_H CS_PORT->BSRR = CS_PIN_MASK
+  #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Define the RD (TFT Read) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
-#ifdef TFT_RD
-  #if (TFT_RD >= 0)
-    // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
-    #define RD_PORT      digitalPinToPort(TFT_RD)
-    #define RD_PIN_MASK  digitalPinToBitMask(TFT_RD)
-    // Use bit set reset register
-    #define RD_L RD_PORT->BSRR = RD_PIN_MASK<<16
-    #define RD_H RD_PORT->BSRR = RD_PIN_MASK
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #ifdef TFT_RD_Pin
+    #if (TFT_RD_Pin >= 0)
+      // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+      #define RD_PORT      TFT_RD_GPIO_Port
+      #define RD_PIN_MASK  TFT_RD_Pin
+      // Use bit set reset register
+      #define RD_L RD_PORT->BSRR = RD_PIN_MASK<<16
+      #define RD_H RD_PORT->BSRR = RD_PIN_MASK
+    #else
+      #define RD_L
+      #define RD_H
+    #endif
   #else
+    #define TFT_RD -1
     #define RD_L
     #define RD_H
   #endif
 #else
-  #define TFT_RD -1
-  #define RD_L
-  #define RD_H
+  #ifdef TFT_RD
+    #if (TFT_RD >= 0)
+      // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+      #define RD_PORT      digitalPinToPort(TFT_RD)
+      #define RD_PIN_MASK  digitalPinToBitMask(TFT_RD)
+      // Use bit set reset register
+      #define RD_L RD_PORT->BSRR = RD_PIN_MASK<<16
+      #define RD_H RD_PORT->BSRR = RD_PIN_MASK
+    #else
+      #define RD_L
+      #define RD_H
+    #endif
+  #else
+    #define TFT_RD -1
+    #define RD_L
+    #define RD_H
+  #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Define the WR (TFT Write) pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
-#ifdef TFT_WR
-  // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
-  #define WR_PORT      digitalPinToPort(TFT_WR)
-  #define WR_PIN_MASK  digitalPinToBitMask(TFT_WR)
-  // Use bit set reset register
-  #define WR_L WR_PORT->BSRR = WR_PIN_MASK<<16
-  #define WR_H WR_PORT->BSRR = WR_PIN_MASK
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #ifdef TFT_WR_Pin
+    // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+    #define WR_PORT      TFT_WR_GPIO_Port
+    #define WR_PIN_MASK  TFT_WR_Pin
+    // Use bit set reset register
+    #define WR_L WR_PORT->BSRR = WR_PIN_MASK<<16
+    #define WR_H WR_PORT->BSRR = WR_PIN_MASK
+  #endif
+#else
+  #ifdef TFT_WR
+    // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
+    #define WR_PORT      digitalPinToPort(TFT_WR)
+    #define WR_PIN_MASK  digitalPinToBitMask(TFT_WR)
+    // Use bit set reset register
+    #define WR_L WR_PORT->BSRR = WR_PIN_MASK<<16
+    #define WR_H WR_PORT->BSRR = WR_PIN_MASK
+  #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Define the touch screen chip select pin drive code
 ////////////////////////////////////////////////////////////////////////////////////////
-#if !defined (TOUCH_CS) || (TOUCH_CS < 0)
-  #define T_CS_L // No macro allocated so it generates no code
-  #define T_CS_H // No macro allocated so it generates no code
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if !defined (TOUCH_CS_Pin) || (TOUCH_CS_Pin < 0)
+    #define T_CS_L // No macro allocated so it generates no code
+    #define T_CS_H // No macro allocated so it generates no code
+  #else
+    // Speed is not important for this signal
+    #define T_CS_L digitalWrite(TOUCH_CS, LOW)
+    #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+  #endif
 #else
-  // Speed is not important for this signal
-  #define T_CS_L digitalWrite(TOUCH_CS, LOW)
-  #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+  #if !defined (TOUCH_CS) || (TOUCH_CS < 0)
+    #define T_CS_L // No macro allocated so it generates no code
+    #define T_CS_H // No macro allocated so it generates no code
+  #else
+    // Speed is not important for this signal
+    #define T_CS_L digitalWrite(TOUCH_CS, LOW)
+    #define T_CS_H digitalWrite(TOUCH_CS, HIGH)
+  #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -792,15 +870,27 @@
     #else
       // This will work with any STM32 to parallel TFT pin mapping but will be slower
 
+      // if CubeMX is used, sssign the CubeMX pin reference to port and mask else
       // Convert Arduino pin reference Dx or STM pin reference PXn to port and mask
-      #define D0_PIN_NAME  digitalPinToPinName(TFT_D0)
-      #define D1_PIN_NAME  digitalPinToPinName(TFT_D1)
-      #define D2_PIN_NAME  digitalPinToPinName(TFT_D2)
-      #define D3_PIN_NAME  digitalPinToPinName(TFT_D3)
-      #define D4_PIN_NAME  digitalPinToPinName(TFT_D4)
-      #define D5_PIN_NAME  digitalPinToPinName(TFT_D5)
-      #define D6_PIN_NAME  digitalPinToPinName(TFT_D6)
-      #define D7_PIN_NAME  digitalPinToPinName(TFT_D7)
+      #ifdef CONFIG_TFT_eSPI_STM32CUBE
+        #define D0_PIN_NAME  TFT_D0_Pin
+        #define D1_PIN_NAME  TFT_D1_Pin
+        #define D2_PIN_NAME  TFT_D2_Pin
+        #define D3_PIN_NAME  TFT_D3_Pin
+        #define D4_PIN_NAME  TFT_D4_Pin
+        #define D5_PIN_NAME  TFT_D5_Pin
+        #define D6_PIN_NAME  TFT_D6_Pin
+        #define D7_PIN_NAME  TFT_D7_Pin
+      #else
+        #define D0_PIN_NAME  digitalPinToPinName(TFT_D0)
+        #define D1_PIN_NAME  digitalPinToPinName(TFT_D1)
+        #define D2_PIN_NAME  digitalPinToPinName(TFT_D2)
+        #define D3_PIN_NAME  digitalPinToPinName(TFT_D3)
+        #define D4_PIN_NAME  digitalPinToPinName(TFT_D4)
+        #define D5_PIN_NAME  digitalPinToPinName(TFT_D5)
+        #define D6_PIN_NAME  digitalPinToPinName(TFT_D6)
+        #define D7_PIN_NAME  digitalPinToPinName(TFT_D7)
+      #endif
 
       // Pin port bit number 0-15
       #define D0_PIN_BIT  (D0_PIN_NAME & 0xF)
@@ -813,24 +903,46 @@
       #define D7_PIN_BIT  (D7_PIN_NAME & 0xF)
 
       // Pin port
-      #define D0_PIN_PORT  digitalPinToPort(TFT_D0)
-      #define D1_PIN_PORT  digitalPinToPort(TFT_D1)
-      #define D2_PIN_PORT  digitalPinToPort(TFT_D2)
-      #define D3_PIN_PORT  digitalPinToPort(TFT_D3)
-      #define D4_PIN_PORT  digitalPinToPort(TFT_D4)
-      #define D5_PIN_PORT  digitalPinToPort(TFT_D5)
-      #define D6_PIN_PORT  digitalPinToPort(TFT_D6)
-      #define D7_PIN_PORT  digitalPinToPort(TFT_D7)
+      #ifdef CONFIG_TFT_eSPI_STM32CUBE
+        #define D0_PIN_PORT  TFT_D0_GPIO_Port
+        #define D1_PIN_PORT  TFT_D1_GPIO_Port
+        #define D2_PIN_PORT  TFT_D2_GPIO_Port
+        #define D3_PIN_PORT  TFT_D3_GPIO_Port
+        #define D4_PIN_PORT  TFT_D4_GPIO_Port
+        #define D5_PIN_PORT  TFT_D5_GPIO_Port
+        #define D6_PIN_PORT  TFT_D6_GPIO_Port
+        #define D7_PIN_PORT  TFT_D7_GPIO_Port
+      #else
+        #define D0_PIN_PORT  digitalPinToPort(TFT_D0)
+        #define D1_PIN_PORT  digitalPinToPort(TFT_D1)
+        #define D2_PIN_PORT  digitalPinToPort(TFT_D2)
+        #define D3_PIN_PORT  digitalPinToPort(TFT_D3)
+        #define D4_PIN_PORT  digitalPinToPort(TFT_D4)
+        #define D5_PIN_PORT  digitalPinToPort(TFT_D5)
+        #define D6_PIN_PORT  digitalPinToPort(TFT_D6)
+        #define D7_PIN_PORT  digitalPinToPort(TFT_D7)
+      #endif
 
       // Pin masks for set/clear
-      #define D0_PIN_MASK  digitalPinToBitMask(TFT_D0)
-      #define D1_PIN_MASK  digitalPinToBitMask(TFT_D1)
-      #define D2_PIN_MASK  digitalPinToBitMask(TFT_D2)
-      #define D3_PIN_MASK  digitalPinToBitMask(TFT_D3)
-      #define D4_PIN_MASK  digitalPinToBitMask(TFT_D4)
-      #define D5_PIN_MASK  digitalPinToBitMask(TFT_D5)
-      #define D6_PIN_MASK  digitalPinToBitMask(TFT_D6)
-      #define D7_PIN_MASK  digitalPinToBitMask(TFT_D7)
+      #ifdef CONFIG_TFT_eSPI_STM32CUBE
+        #define D0_PIN_MASK  (D0_PIN_NAME)
+        #define D1_PIN_MASK  (D1_PIN_NAME)
+        #define D2_PIN_MASK  (D2_PIN_NAME)
+        #define D3_PIN_MASK  (D3_PIN_NAME)
+        #define D4_PIN_MASK  (D4_PIN_NAME)
+        #define D5_PIN_MASK  (D5_PIN_NAME)
+        #define D6_PIN_MASK  (D6_PIN_NAME)
+        #define D7_PIN_MASK  (D7_PIN_NAME)
+      #else
+        #define D0_PIN_MASK  digitalPinToBitMask(TFT_D0)
+        #define D1_PIN_MASK  digitalPinToBitMask(TFT_D1)
+        #define D2_PIN_MASK  digitalPinToBitMask(TFT_D2)
+        #define D3_PIN_MASK  digitalPinToBitMask(TFT_D3)
+        #define D4_PIN_MASK  digitalPinToBitMask(TFT_D4)
+        #define D5_PIN_MASK  digitalPinToBitMask(TFT_D5)
+        #define D6_PIN_MASK  digitalPinToBitMask(TFT_D6)
+        #define D7_PIN_MASK  digitalPinToBitMask(TFT_D7)
+      #endif
 
       // Create bit set/reset mask based on LS byte of value B
       #define  D0_BSR_MASK(B) ((D0_PIN_MASK<<16)>>(((B)<< 4)&0x10))
@@ -1074,6 +1186,24 @@
 #elif !defined (TFT_PARALLEL_8_BIT)
   // Use a SPI read transfer
   #define tft_Read_8() spi.transfer(0)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Other Macros to support Arduino functions
+////////////////////////////////////////////////////////////////////////////////////////
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+  #define pgm_read_word(addr) (*(const unsigned short *)(addr))
+  #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
+  #define pgm_read_float(addr) (*(const float *)(addr))
+
+  #define delay(x)  HAL_Delay(x)
+  #define random(x) random()*x
+  #define yield()
+
+  #define min(a,b) (((a)<(b))?(a):(b))
+  #define max(a,b) (((a)>(b))?(a):(b))
+
 #endif
 
 #endif // Header end

--- a/Processors/TFT_eSPI_STM32.h
+++ b/Processors/TFT_eSPI_STM32.h
@@ -89,10 +89,10 @@
       //#define WR_TWRL_2
       #define WR_TWRL_3
     #else
-      //#define WR_TWRH_0    // Fastest
-      //#define WR_TWRH_1
-      //#define WR_TWRH_2
-      #define WR_TWRH_3      // Slowest
+      //#define WR_TWRL_0    // Fastest
+      //#define WR_TWRL_1
+      //#define WR_TWRL_2
+      #define WR_TWRL_3      // Slowest
     #endif
 
     // Extra write pulse high time (data hold time, delays next write cycle start)

--- a/TFT_STM32cube_config.h
+++ b/TFT_STM32cube_config.h
@@ -1,0 +1,227 @@
+//                            USER DEFINED SETTINGS
+//   Set driver type, fonts to be loaded, pins used and SPI control method etc
+//
+//
+//   If this file is edited correctly then all the library example sketches should
+//   run without the need to make any more changes for a particular hardware setup!
+//   Note that some sketches are designed for a particular TFT pixel width/height
+
+#ifndef TFT_STM32CUBE_CONFIG_H
+#define TFT_STM32CUBE_CONFIG_H
+
+// User defined information reported by "Read_User_Setup" test & diagnostics example
+#define USER_SETUP_LOADED
+#define USER_SETUP_INFO "User_Setup"
+
+#define INPUT         0x0
+#define OUTPUT        0x1
+
+// Define to disable all #warnings in library (can be put in User_Setup_Select.h)
+//#define DISABLE_ALL_LIBRARY_WARNINGS
+
+// ##################################################################################
+//
+// Section 1. Call up the right driver file and any options for it
+//
+// ##################################################################################
+
+// Define STM32 to invoke optimised processor support (only for STM32)
+#define STM32
+
+// STM32 8 bit parallel only:
+// If STN32 Port A or B pins 0-7 are used for 8 bit parallel data bus bits 0-7
+// then this will improve rendering performance by a factor of ~8x
+//#define STM_PORTA_DATA_BUS
+//#define STM_PORTB_DATA_BUS
+
+// Tell the library to use parallel mode (otherwise SPI is assumed)
+#define TFT_PARALLEL_8_BIT
+
+// Display type -  only define if RPi display
+//#define RPI_DISPLAY_TYPE // 20MHz maximum SPI
+
+// Only define one driver, the other ones must be commented out
+//#define ILI9341_DRIVER       // Generic driver for common displays
+//#define ILI9341_2_DRIVER     // Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
+//#define ST7735_DRIVER      // Define additional parameters below for this display
+//#define ILI9163_DRIVER     // Define additional parameters below for this display
+//#define S6D02A1_DRIVER
+//#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
+//#define HX8357D_DRIVER
+#define ILI9481_DRIVER
+//#define ILI9486_DRIVER
+//#define ILI9488_DRIVER     // WARNING: Do not connect ILI9488 display SDO to MISO if other devices share the SPI bus (TFT SDO does NOT tristate when CS is high)
+//#define ST7789_DRIVER      // Full configuration option, define additional parameters below for this display
+//#define ST7789_2_DRIVER    // Minimal configuration option, define additional parameters below for this display
+//#define R61581_DRIVER
+//#define RM68140_DRIVER
+//#define ST7796_DRIVER
+//#define SSD1351_DRIVER
+//#define SSD1963_480_DRIVER
+//#define SSD1963_800_DRIVER
+//#define SSD1963_800ALT_DRIVER
+//#define ILI9225_DRIVER
+//#define GC9A01_DRIVER
+
+// Some displays support SPI reads via the MISO pin, other displays have a single
+// bi-directional SDA pin and the library will try to read this via the MOSI line.
+// To use the SDA line for reading data from the TFT uncomment the following line:
+
+// #define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 and GC9A01 display only
+
+// For ST7735, ST7789 and ILI9341 ONLY, define the colour order IF the blue and red are swapped on your display
+// Try ONE option at a time to find the correct colour order for your display
+
+//  #define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+//  #define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
+// For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
+// #define TFT_WIDTH  80
+// #define TFT_WIDTH  128
+// #define TFT_WIDTH  172 // ST7789 172 x 320
+// #define TFT_WIDTH  170 // ST7789 170 x 320
+// #define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
+// #define TFT_HEIGHT 160
+// #define TFT_HEIGHT 128
+// #define TFT_HEIGHT 240 // ST7789 240 x 240
+// #define TFT_HEIGHT 320 // ST7789 240 x 320
+// #define TFT_HEIGHT 240 // GC9A01 240 x 240
+
+// For ST7735 ONLY, define the type of display, originally this was based on the
+// colour of the tab on the screen protector film but this is not always true, so try
+// out the different options below if the screen does not display graphics correctly,
+// e.g. colours wrong, mirror images, or stray pixels at the edges.
+// Comment out ALL BUT ONE of these options for a ST7735 display driver, save this
+// this User_Setup file, then rebuild and upload the sketch to the board again:
+
+// #define ST7735_INITB
+// #define ST7735_GREENTAB
+// #define ST7735_GREENTAB2
+// #define ST7735_GREENTAB3
+// #define ST7735_GREENTAB128    // For 128 x 128 display
+// #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
+// #define ST7735_ROBOTLCD       // For some RobotLCD arduino shields (128x160, BGR, https://docs.arduino.cc/retired/getting-started-guides/TFT)
+// #define ST7735_REDTAB
+// #define ST7735_BLACKTAB
+// #define ST7735_REDTAB160x80   // For 160 x 80 display with 24 pixel offset
+
+// If colours are inverted (white shows as black) then uncomment one of the next
+// 2 lines try both options, one of the options should correct the inversion.
+
+// #define TFT_INVERSION_ON
+// #define TFT_INVERSION_OFF
+
+
+// ##################################################################################
+//
+// Section 2. Define the pins that are used to interface with the display here
+//
+// ##################################################################################
+
+// If a backlight control signal is available then define the TFT_BL pin in Section 2
+// below. The backlight will be turned ON when tft.begin() is called, but the library
+// needs to know if the LEDs are ON with the pin HIGH or LOW. If the LEDs are to be
+// driven with a PWM signal or turned OFF/ON then this must be handled by the user
+// sketch. e.g. with digitalWrite(TFT_BL, LOW);
+
+#define TFT_BL_   32         // LED back-light control pin
+#define TFT_BACKLIGHT_ON 1  // Level to turn ON back-light (1 or 0)
+
+// We must use hardware SPI, a minimum of 3 GPIO pins is needed.
+// The TFT RESET pin can be connected to the NodeMCU RST pin or 3.3V to free up a control pin
+//
+// The DC (Data Command) pin may be labelled AO or RS (Register Select)
+//
+// With some displays such as the ILI9341 the TFT CS pin can be connected to GND if no more
+// SPI devices (e.g. an SD Card) are connected, in this case comment out the #define TFT_CS
+// line below so it is NOT defined. Other displays such at the ST7735 require the TFT CS pin
+// to be toggled during setup, so in these cases the TFT_CS line must be defined and connected.
+
+// ######       EDIT THE PINs BELOW TO SUIT YOUR STM32 SPI TFT SETUP        ######
+
+// The TFT can be connected to SPI port 1 or 2
+//#define TFT_SPI_PORT 1 // SPI port 1 maximum clock rate is 55MHz
+//define TFT_MOSI PA7
+//define TFT_MISO PA6
+//define TFT_SCLK PA5
+
+//#define TFT_SPI_PORT 2 // SPI port 2 maximum clock rate is 27MHz
+//#define TFT_MOSI PB15
+//#define TFT_MISO PB14
+//#define TFT_SCLK PB13
+
+// Can use Ardiuno pin references, arbitrary allocation, TFT_eSPI controls chip select
+//#define TFT_CS   D5 // Chip select control pin to TFT CS
+//#define TFT_DC   D6 // Data Command control pin to TFT DC (may be labelled RS = Register Select)
+//#define TFT_RST  D7 // Reset pin to TFT RST (or RESET)
+// OR alternatively, we can use STM32 port reference names PXnn
+
+//#define TFT_CS   PE11 // Nucleo-F767ZI equivalent of D5
+//#define TFT_DC   PE9  // Nucleo-F767ZI equivalent of D6
+//#define TFT_RST  PF13 // Nucleo-F767ZI equivalent of D7
+
+//#define TFT_RST  -1   // Set TFT_RST to -1 if the display RESET is connected to processor reset
+                        // Use an Arduino pin for initial testing as connecting to processor reset
+                        // may not work (pulse too short at power up?)
+
+// ##################################################################################
+//
+// Section 3. Define the fonts that are to be used here
+//
+// ##################################################################################
+
+// Comment out the #defines below with // to stop that font being loaded
+// If all fonts are loaded the extra FLASH space required is
+// about 17Kbytes. To save FLASH space only enable the fonts you need!
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+// Comment out the #define below to stop the SPIFFS filing system and smooth font code being loaded
+// this will save ~20kbytes of FLASH
+#define SMOOTH_FONT
+
+
+// ##################################################################################
+//
+// Section 4. Other options
+//
+// ##################################################################################
+
+// For the STM32 processor define the SPI port channel used (default 1 if undefined)
+//#define TFT_SPI_PORT 1 // Set to 1 for SPI port 1, or 2 for SPI port 2
+
+// Define the SPI clock frequency, this affects the graphics rendering speed. Too
+// fast and the TFT driver will not keep up and display corruption appears.
+// With an ILI9341 display 40MHz works OK, 80MHz sometimes fails
+// With a ST7735 display more than 27MHz may not work (spurious pixels and lines)
+// With an ILI9163 display 27 MHz works OK.
+
+// #define SPI_FREQUENCY   1000000
+// #define SPI_FREQUENCY   5000000
+// #define SPI_FREQUENCY  10000000
+// #define SPI_FREQUENCY  20000000
+// #define SPI_FREQUENCY  27000000
+// #define SPI_FREQUENCY  40000000
+//#define SPI_FREQUENCY  55000000 // STM32 SPI1 only (SPI2 maximum is 27MHz)
+// #define SPI_FREQUENCY  80000000
+
+// Optional reduced SPI frequency for reading TFT
+//#define SPI_READ_FREQUENCY  20000000
+
+// Comment out the following #define if "SPI Transactions" do not need to be
+// supported. When commented out the code size will be smaller and sketches will
+// run slightly faster, so leave it commented out unless you need it!
+
+// Transaction support is needed to work with SD library but not needed with TFT_SdFat
+// Transaction support is required if other SPI devices are connected.
+
+// #define SUPPORT_TRANSACTIONS
+
+#endif // TFT_STM32CUBE_CONFIG_H

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -532,61 +532,114 @@ TFT_eSPI::TFT_eSPI(int16_t w, int16_t h)
 ***************************************************************************************/
 void TFT_eSPI::initBus(void) {
 
-#ifdef TFT_CS
-  if (TFT_CS >= 0) {
-    pinMode(TFT_CS, OUTPUT);
-    digitalWrite(TFT_CS, HIGH); // Chip select high (inactive)
-  }
-#endif
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  // We dont need to set the pinMode, this is done by CubeMX generated code.
+  #ifdef TFT_CS_Pin
+    if (TFT_CS_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_CS_GPIO_Port, TFT_CS_Pin); // Chip select high (inactive)
+    }
+  #endif
 
-// Configure chip select for touchscreen controller if present
-#ifdef TOUCH_CS
-  if (TOUCH_CS >= 0) {
-    pinMode(TOUCH_CS, OUTPUT);
-    digitalWrite(TOUCH_CS, HIGH); // Chip select high (inactive)
-  }
-#endif
+  // Configure chip select for touchscreen controller if present
+  #ifdef TOUCH_CS_Pin
+    if (TOUCH_CS_Pin >= 0) {;
+      digitalWrite(TOUCH_CS, HIGH); // Chip select high (inactive)
+    }
+  #endif
 
-// In parallel mode and with the RP2040 processor, the TFT_WR line is handled in the  PIO
-#if defined (TFT_WR) && !defined (ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED)
-  if (TFT_WR >= 0) {
-    pinMode(TFT_WR, OUTPUT);
-    digitalWrite(TFT_WR, HIGH); // Set write strobe high (inactive)
-  }
-#endif
+  #if defined (TFT_WR_Pin)
+    if (TFT_WR_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_WR_GPIO_Port, TFT_WR_Pin);  // Set write strobe high (inactive)
+    }
+  #endif
 
-#ifdef TFT_DC
-  if (TFT_DC >= 0) {
-    pinMode(TFT_DC, OUTPUT);
-    digitalWrite(TFT_DC, HIGH); // Data/Command high = data mode
-  }
-#endif
+  #ifdef TFT_DC_Pin
+    if (TFT_DC_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_DC_GPIO_Port, TFT_DC_Pin);  // Data/Command high = data mode
+    }
+  #endif
 
-#ifdef TFT_RST
-  if (TFT_RST >= 0) {
-    pinMode(TFT_RST, OUTPUT);
-    digitalWrite(TFT_RST, HIGH); // Set high, do not share pin with another SPI device
-  }
+  #ifdef TFT_RST_Pin
+    if (TFT_RST_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_RST_GPIO_Port, TFT_RST_Pin); // Set high, do not share pin with another SPI device
+    }
+  #endif
+#else
+  #ifdef TFT_CS
+    if (TFT_CS >= 0) {
+      pinMode(TFT_CS, OUTPUT);
+      digitalWrite(TFT_CS, HIGH); // Chip select high (inactive)
+    }
+  #endif
+
+  // Configure chip select for touchscreen controller if present
+  #ifdef TOUCH_CS
+    if (TOUCH_CS >= 0) {
+      pinMode(TOUCH_CS, OUTPUT);
+      digitalWrite(TOUCH_CS, HIGH); // Chip select high (inactive)
+    }
+  #endif
+
+  // In parallel mode and with the RP2040 processor, the TFT_WR line is handled in the  PIO
+  #if defined (TFT_WR) && !defined (ARDUINO_ARCH_RP2040) && !defined (ARDUINO_ARCH_MBED)
+    if (TFT_WR >= 0) {
+      pinMode(TFT_WR, OUTPUT);
+      digitalWrite(TFT_WR, HIGH); // Set write strobe high (inactive)
+    }
+  #endif
+
+  #ifdef TFT_DC
+    if (TFT_DC >= 0) {
+      pinMode(TFT_DC, OUTPUT);
+      digitalWrite(TFT_DC, HIGH); // Data/Command high = data mode
+    }
+  #endif
+
+  #ifdef TFT_RST
+    if (TFT_RST >= 0) {
+      pinMode(TFT_RST, OUTPUT);
+      digitalWrite(TFT_RST, HIGH); // Set high, do not share pin with another SPI device
+    }
+  #endif
 #endif
 
 #if defined (TFT_PARALLEL_8_BIT)
 
-  // Make sure read is high before we set the bus to output
-  if (TFT_RD >= 0) {
-    pinMode(TFT_RD, OUTPUT);
-    digitalWrite(TFT_RD, HIGH);
-  }
+  #ifdef CONFIG_TFT_eSPI_STM32CUBE
+    // Make sure read is high before we set the bus to output
+    if (TFT_RD_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_RD_GPIO_Port, TFT_RD_Pin);
+    }
 
-  #if  !defined (ARDUINO_ARCH_RP2040)  && !defined (ARDUINO_ARCH_MBED)// PIO manages pins
-    // Set TFT data bus lines to output
-    pinMode(TFT_D0, OUTPUT); digitalWrite(TFT_D0, HIGH);
-    pinMode(TFT_D1, OUTPUT); digitalWrite(TFT_D1, HIGH);
-    pinMode(TFT_D2, OUTPUT); digitalWrite(TFT_D2, HIGH);
-    pinMode(TFT_D3, OUTPUT); digitalWrite(TFT_D3, HIGH);
-    pinMode(TFT_D4, OUTPUT); digitalWrite(TFT_D4, HIGH);
-    pinMode(TFT_D5, OUTPUT); digitalWrite(TFT_D5, HIGH);
-    pinMode(TFT_D6, OUTPUT); digitalWrite(TFT_D6, HIGH);
-    pinMode(TFT_D7, OUTPUT); digitalWrite(TFT_D7, HIGH);
+    #if  !defined (ARDUINO_ARCH_RP2040)  && !defined (ARDUINO_ARCH_MBED)// PIO manages pins
+      // We dont need to set the pinMode, this is done by CubeMX generated code.
+      LL_GPIO_SetOutputPin(TFT_D0_GPIO_Port, TFT_D0_Pin);
+      LL_GPIO_SetOutputPin(TFT_D1_GPIO_Port, TFT_D1_Pin);
+      LL_GPIO_SetOutputPin(TFT_D2_GPIO_Port, TFT_D2_Pin);
+      LL_GPIO_SetOutputPin(TFT_D3_GPIO_Port, TFT_D3_Pin);
+      LL_GPIO_SetOutputPin(TFT_D4_GPIO_Port, TFT_D4_Pin);
+      LL_GPIO_SetOutputPin(TFT_D5_GPIO_Port, TFT_D5_Pin);
+      LL_GPIO_SetOutputPin(TFT_D6_GPIO_Port, TFT_D6_Pin);
+      LL_GPIO_SetOutputPin(TFT_D7_GPIO_Port, TFT_D7_Pin);
+    #endif
+  #else
+    // Make sure read is high before we set the bus to output
+    if (TFT_RD >= 0) {
+      pinMode(TFT_RD, OUTPUT);
+      digitalWrite(TFT_RD, HIGH);
+    }
+
+    #if  !defined (ARDUINO_ARCH_RP2040)  && !defined (ARDUINO_ARCH_MBED)// PIO manages pins
+      // Set TFT data bus lines to output
+      pinMode(TFT_D0, OUTPUT); digitalWrite(TFT_D0, HIGH);
+      pinMode(TFT_D1, OUTPUT); digitalWrite(TFT_D1, HIGH);
+      pinMode(TFT_D2, OUTPUT); digitalWrite(TFT_D2, HIGH);
+      pinMode(TFT_D3, OUTPUT); digitalWrite(TFT_D3, HIGH);
+      pinMode(TFT_D4, OUTPUT); digitalWrite(TFT_D4, HIGH);
+      pinMode(TFT_D5, OUTPUT); digitalWrite(TFT_D5, HIGH);
+      pinMode(TFT_D6, OUTPUT); digitalWrite(TFT_D6, HIGH);
+      pinMode(TFT_D7, OUTPUT); digitalWrite(TFT_D7, HIGH);
+    #endif
   #endif
 
   PARALLEL_INIT_TFT_DATA_BUS;
@@ -656,24 +709,40 @@ void TFT_eSPI::init(uint8_t tc)
 
     INIT_TFT_DATA_BUS;
 
-
-#if defined (TFT_CS) && !defined(RP2040_PIO_INTERFACE)
-  // Set to output once again in case MISO is used for CS
-  if (TFT_CS >= 0) {
-    pinMode(TFT_CS, OUTPUT);
-    digitalWrite(TFT_CS, HIGH); // Chip select high (inactive)
-  }
-#elif defined (ARDUINO_ARCH_ESP8266) && !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_SPI)
-  spi.setHwCs(1); // Use hardware SS toggling
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if defined (TFT_CS_Pin)
+    // Set to output once again in case MISO is used for CS
+    if (TFT_CS_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_CS_GPIO_Port, TFT_CS_Pin); // Chip select high (inactive)
+    }
+  #endif
+#else
+  #if defined (TFT_CS) && !defined(RP2040_PIO_INTERFACE)
+    // Set to output once again in case MISO is used for CS
+    if (TFT_CS >= 0) {
+      pinMode(TFT_CS, OUTPUT);
+      digitalWrite(TFT_CS, HIGH); // Chip select high (inactive)
+    }
+  #elif defined (ARDUINO_ARCH_ESP8266) && !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_SPI)
+    spi.setHwCs(1); // Use hardware SS toggling
+  #endif
 #endif
 
 
   // Set to output once again in case MISO is used for DC
-#if defined (TFT_DC) && !defined(RP2040_PIO_INTERFACE)
-  if (TFT_DC >= 0) {
-    pinMode(TFT_DC, OUTPUT);
-    digitalWrite(TFT_DC, HIGH); // Data/Command high = data mode
-  }
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if defined (TFT_DC_Pin)
+    if (TFT_DC_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_DC_GPIO_Port, TFT_DC_Pin);// Data/Command high = data mode
+    }
+  #endif
+#else
+  #if defined (TFT_DC) && !defined(RP2040_PIO_INTERFACE)
+    if (TFT_DC >= 0) {
+      pinMode(TFT_DC, OUTPUT);
+      digitalWrite(TFT_DC, HIGH); // Data/Command high = data mode
+    }
+  #endif
 #endif
 
     _booted = false;
@@ -681,24 +750,41 @@ void TFT_eSPI::init(uint8_t tc)
   } // end of: if just _booted
 
   // Toggle RST low to reset
-#ifdef TFT_RST
-  #if !defined(RP2040_PIO_INTERFACE)
-    // Set to output once again in case MISO is used for TFT_RST
-    if (TFT_RST >= 0) {
-      pinMode(TFT_RST, OUTPUT);
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #ifdef TFT_RST_Pin
+      // Set to output once again in case MISO is used for TFT_RST
+    if (TFT_RST_Pin >= 0) {
+      writecommand(0x00); // Put SPI bus in known state for TFT with CS tied low
+      LL_GPIO_SetOutputPin(TFT_RST_GPIO_Port, TFT_RST_Pin);
+      HAL_Delay(5);
+      LL_GPIO_ResetOutputPin(TFT_RST_GPIO_Port, TFT_RST_Pin);
+      HAL_Delay(20);
+      LL_GPIO_SetOutputPin(TFT_RST_GPIO_Port, TFT_RST_Pin);
     }
+    else writecommand(TFT_SWRST); // Software reset
+  #else
+    writecommand(TFT_SWRST); // Software reset
   #endif
-  if (TFT_RST >= 0) {
-    writecommand(0x00); // Put SPI bus in known state for TFT with CS tied low
-    digitalWrite(TFT_RST, HIGH);
-    delay(5);
-    digitalWrite(TFT_RST, LOW);
-    delay(20);
-    digitalWrite(TFT_RST, HIGH);
-  }
-  else writecommand(TFT_SWRST); // Software reset
 #else
-  writecommand(TFT_SWRST); // Software reset
+  #ifdef TFT_RST
+    #if !defined(RP2040_PIO_INTERFACE)
+      // Set to output once again in case MISO is used for TFT_RST
+      if (TFT_RST >= 0) {
+        pinMode(TFT_RST, OUTPUT);
+      }
+    #endif
+    if (TFT_RST >= 0) {
+      writecommand(0x00); // Put SPI bus in known state for TFT with CS tied low
+      digitalWrite(TFT_RST, HIGH);
+      delay(5);
+      digitalWrite(TFT_RST, LOW);
+      delay(20);
+      digitalWrite(TFT_RST, HIGH);
+    }
+    else writecommand(TFT_SWRST); // Software reset
+  #else
+    writecommand(TFT_SWRST); // Software reset
+  #endif
 #endif
 
   delay(150); // Wait for reset to complete
@@ -783,18 +869,33 @@ void TFT_eSPI::init(uint8_t tc)
 
   setRotation(rotation);
 
-#if defined (TFT_BL) && defined (TFT_BACKLIGHT_ON)
-  if (TFT_BL >= 0) {
-    pinMode(TFT_BL, OUTPUT);
-    digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
-  }
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #if defined (TFT_BL_Pin) && defined (TFT_BACKLIGHT_ON)
+    if (TFT_BL_Pin >= 0) {
+      LL_GPIO_SetOutputPin(TFT_BL_GPIO_Port, TFT_BL_Pin);
+    }
+  #else
+    #if defined (TFT_BL) && defined (M5STACK)
+      // Turn on the back-light LED
+      if (TFT_BL_Pin >= 0) {
+        LL_GPIO_SetOutputPin(TFT_BL_GPIO_Port, TFT_BL_Pin);
+      }
+    #endif
+  #endif
 #else
-  #if defined (TFT_BL) && defined (M5STACK)
-    // Turn on the back-light LED
+  #if defined (TFT_BL) && defined (TFT_BACKLIGHT_ON)
     if (TFT_BL >= 0) {
       pinMode(TFT_BL, OUTPUT);
-      digitalWrite(TFT_BL, HIGH);
+      digitalWrite(TFT_BL, TFT_BACKLIGHT_ON);
     }
+  #else
+    #if defined (TFT_BL) && defined (M5STACK)
+      // Turn on the back-light LED
+      if (TFT_BL >= 0) {
+        pinMode(TFT_BL, OUTPUT);
+        digitalWrite(TFT_BL, HIGH);
+      }
+    #endif
   #endif
 #endif
 }
@@ -872,7 +973,11 @@ void TFT_eSPI::setRotation(uint8_t m)
 
 #endif
 
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  HAL_Delay(1);   // To long, but for now no alternative.
+#else
   delayMicroseconds(10);
+#endif
 
   end_tft_write();
 
@@ -4256,7 +4361,7 @@ void TFT_eSPI::fillSmoothCircle(int32_t x, int32_t y, int32_t r, uint32_t color,
   int32_t r1 = r * r;
   r++;
   int32_t r2 = r * r;
-  
+
   for (int32_t cy = r - 1; cy > 0; cy--)
   {
     int32_t dy2 = (r - cy) * (r - cy);
@@ -6100,6 +6205,7 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
   tft_settings.pin_tft_rst = -1;
 #endif
 
+#ifndef CONFIG_TFT_eSPI_STM32CUBE
 #if defined (TFT_PARALLEL_8_BIT) || defined(TFT_PARALLEL_16_BIT)
   tft_settings.pin_tft_d0 = TFT_D0;
   tft_settings.pin_tft_d1 = TFT_D1;
@@ -6118,6 +6224,7 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
   tft_settings.pin_tft_d5 = -1;
   tft_settings.pin_tft_d6 = -1;
   tft_settings.pin_tft_d7 = -1;
+#endif
 #endif
 
 #if defined (TFT_BL)

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -27,11 +27,15 @@
 ***************************************************************************************/
 
 //Standard support
-#include <Arduino.h>
-#include <Print.h>
-#if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
-  #include <SPI.h>
+#ifndef CONFIG_TFT_eSPI_STM32CUBE
+  #include <Arduino.h>
+
+  #if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
+    #include <SPI.h>
+  #endif
 #endif
+#include <Print.h>
+
 /***************************************************************************************
 **                         Section 2: Load library and processor specific header files
 ***************************************************************************************/
@@ -39,6 +43,10 @@
 // available and the pins to be used, etc. etc.
 #ifdef CONFIG_TFT_eSPI_ESPIDF
   #include "TFT_config.h"
+#endif
+
+#ifdef CONFIG_TFT_eSPI_STM32CUBE
+  #include "TFT_STM32cube_config.h"
 #endif
 
 // New ESP8266 board package uses ARDUINO_ARCH_ESP8266
@@ -820,7 +828,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
   bool     verifySetupID(uint32_t id);
 
   // Global variables
-#if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE)
+#if !defined (TFT_PARALLEL_8_BIT) && !defined (RP2040_PIO_INTERFACE) && !defined (CONFIG_TFT_eSPI_STM32CUBE)
   static   SPIClass& getSPIinstance(void); // Get SPI class handle
 #endif
   uint32_t textcolor, textbgcolor;         // Text foreground and background colours

--- a/docs/CubeMX/README
+++ b/docs/CubeMX/README
@@ -1,0 +1,62 @@
+This file describes the use of TFT_eSPI with the STM32CubeMX (short CubeMX)
+program. It can also be used in Platformio with the stm32cube framework.
+It is tested with both.
+
+CubeMX can generate all pin configuration and initial setup. So TFT_eSPI can
+make use of these pinnames and setup.
+
+The use of CubeMX will be described in the next staps. It is assumed the user
+is known with the use of CubeMX and how to create a base project and how to
+create a stm32cube project with the <project>.ioc file from CubeMX
+
+1:  Create a new project in CubeMX and give it some name. Do the basic clock
+    configuration.
+
+2:  Define all pins which shall be used in your project. For now stick to the
+    basic naming of the pins (TFT_DC, TFT_RST, TFT_CS, TFT_BL, TFT_D(0-7))
+    for the parallel usage. For SPI pins use (TFT_MOSI, TFT_MISO and TFT_SCLK).
+    GPIO_INPUT / GPIO_OUTPUT according to the use of the TFT_* port.
+    And further more the pins you want to use.
+
+3:  Save and generate the code.
+
+Now we split into two lines, A for the use in CubeIDE and B for the use in
+Platformio
+
+4A: Create a subdirectory Libraries in you in step 1 created project. Use the
+    main folder, not the 'core' folder.
+    Copy the TFT_eSPI and TFT_Arduino library into the directory Libraries.
+    - Add a 'Define symbol (-D)' to the project with defines
+      CONFIG_TFT_eSPI_STM32CUBE. So -D CONFIG_TFT_eSPI_STM32CUBE.
+    - Add 2 'Include Paths' for your C and C++ compiler.
+      One path '../Libraries/TFT-eSPI' and one '../Libraries/TFT_Arduino'.
+      Also add these path to 'Source Location' in 'Path and Symbols'
+      Create filter and remove all subdirectories of TFT_eSPI.
+    - Build and run the code.
+
+4B: Create a new project with stm32cube as framework. Copy the <project>.ioc
+    to the project main directory.
+    Install the TFT_eSPI library as normal. You can also install it under the
+    'lib' project subdirectory. Install the TFT_Arduino library under the
+    project subdir 'lib'.
+    Use the following platformio.ini as template:
+
+    [env:<mcu>]
+        platform = ststm32
+        board = <mcu>
+        framework = stm32cube
+        build_flags =
+	        -D USE_FULL_LL_DRIVER
+	        -D CONFIG_TFT_eSPI_STM32CUBE
+	        -I lib/TFT_eSPI (only if installed in lib subdirectory)
+	        -I lib/TFT_Arduino
+
+    [platformio]
+    include_dir = Inc
+    src_dir = Src
+
+    Compile and run.
+
+
+
+

--- a/library.json
+++ b/library.json
@@ -16,7 +16,7 @@
         "maintainer": true
     }
   ],
-  "frameworks": "arduino",
+  "frameworks": "arduino, stm32cube",
   "platforms": "raspberrypi, espressif8266, espressif32, ststm32",
   "headers": "TFT_eSPI.h"
 }


### PR DESCRIPTION
This is a PR for using TFT_eSPI with the STM32CUBEIDE (including CubeMX) or Platformio with the stm32cube framework.
I have tested the patch with the parallel version of a ILI9481. 
To activate the use of the framework a '-D CONFIG_TFT_eSPI_STM32CUBE' must be used. Omitting the option falls back to the original use of TFT_eSPI.

There is a README in the Doc/CubeMX  directory which describes all steps.

For now it is working with the Parallel interface, I am working on the SPI interface which will be added in the next days.
However I made a PR to get a review so I can correct all issues during the next upload.

Have any questions then ask!

/Willem