### PR TITLE
Added support for backlights controlled with AnalogWrite

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -783,6 +783,12 @@ void TFT_eSPI::init(uint8_t tc)
 
   setRotation(rotation);
 
+// Enabling backlight for displays with analog controlled backlight leds
+#if defined (TFT_ANALOG_BL) && defined (TFT_ANALOG_BL_POWER)
+  pinMode(TFT_ANALOG_BL, OUTPUT);
+  analogWrite(TFT_ANALOG_BL, TFT_ANALOG_BL_POWER);
+#endif
+	
 #if defined (TFT_BL) && defined (TFT_BACKLIGHT_ON)
   if (TFT_BL >= 0) {
     pinMode(TFT_BL, OUTPUT);

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -132,6 +132,10 @@
 // #define TFT_BL   32            // LED back-light control pin
 // #define TFT_BACKLIGHT_ON HIGH  // Level to turn ON back-light (HIGH or LOW)
 
+// For displays that control backlight through analogOut you should use these
+// ( For example esP32-2424S012 and similar)
+// #define TFT_ANALOG_BL 3 // analogWrite pin LED Backlight through
+// #define TFT_ANALOG_BL_POWER 40 // Power in scale of 0-255 (Start small like 40 and experiment)
 
 
 // We must use hardware SPI, a minimum of 3 GPIO pins is needed.
@@ -239,6 +243,16 @@
 //#define TFT_DC   27  // Data Command control pin
 //#define TFT_RST  33  // Reset pin (could connect to Arduino RESET pin)
 //#define TFT_BL   32  // LED back-light (required for M5Stack)
+
+
+// For the "esP32-2424S012" module use these #define lines
+//#define TFT_MOSI 7 // In some display driver board, it might be written as “SDA” and so on.
+//#define TFT_SCLK 6
+//#define TFT_CS 10 // Chip select control pin
+//#define TFT_DC 2 // Data Command control pin
+//#define TFT_RST -1 // Reset pin (could connect to Arduino RESET pin)
+//#define TFT_ANALOG_BL 3 // Enable backlight for esP32-2424S012)
+//#define TFT_ANALOG_BL_POWER 40 // Set power to 40/255 .
 
 // ######       EDIT THE PINs BELOW TO SUIT YOUR ESP32 PARALLEL TFT SETUP        ######
 


### PR DESCRIPTION
Some modules like "esP32-2424S012" control its backlight through analogWrite.
- Added support for enabling these kind of backlights through normal user_setup.h
- Added example setup for "esP32-2424S012" as commented out definitions.