### PR TITLE
ST7789: Add mirrored display modes to support 2" rounded rectangle TFT LCD display 240*296 pixels

### DIFF
--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -1,7 +1,7 @@
   // This is the command sequence that rotates the ST7789 driver coordinate frame
 
   writecommand(TFT_MADCTL);
-  rotation = m % 4;
+  rotation = m % 8;
   switch (rotation) {
     case 0: // Portrait
 #ifdef CGRAM_OFFSET
@@ -137,4 +137,48 @@
       _width  = _init_height;
       _height = _init_width;
       break;
+
+    case 4: // Portrait + mirrored
+      colstart = 0;
+      rowstart = 0;
+      writedata(TFT_MAD_MX | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_width;
+      _height = _init_height;
+      break;
+
+    case 5: // Landscape (Portrait + 90) + mirrored
+      writedata(TFT_MAD_MV | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_height;
+      _height = _init_width;
+      break;
+
+    case 6: // Inverter portrait + mirrored
+#ifdef CGRAM_OFFSET
+      if(_init_height == 296)
+      {
+        colstart = 0;
+        rowstart = 24;
+      }
+#endif
+      writedata(TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_width;
+      _height = _init_height;
+       break;
+
+    case 7: // Inverted landscape + mirrored
+#ifdef CGRAM_OFFSET
+      if(_init_height == 296)
+      {
+        colstart = 24;
+        rowstart = 0;
+      }
+#endif
+      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_MX |TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_height;
+      _height = _init_width;
+      break;    
   }

--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -160,6 +160,9 @@
       {
         colstart = 0;
         rowstart = 24;
+      } else {
+        colstart = 0;
+        rowstart = 0;
       }
 #endif
       writedata(TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
@@ -174,7 +177,11 @@
       {
         colstart = 24;
         rowstart = 0;
+      } else {
+        colstart = 0;
+        rowstart = 0;
       }
+
 #endif
       writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_MX |TFT_MAD_COLOR_ORDER);
 


### PR DESCRIPTION
This pull request adds support for a new 2" TFT LCD display with a rounded rectangle form factor (240*296 pixels) and ST7789 command set.

The display can be used using following settings:

```
#define ST7789_DRIVER
#define TFT_HEIGHT 296
#define CGRAM_OFFSET
#define TFT_RGB_ORDER TFT_BGR
#define TFT_INVERSION_OFF
#define SPI_FREQUENCY  80000000
```
However, the image is mirrored and in some rotations, there is a 24-pixel offset. This pull request addresses these issues by adding support for four additional rotations (4-7) to the ST7789 driver to enable mirroring. In case CGRAM_OFFSET is defined and the height equals 296 pixels, the offset is set when the display is in a mirrored rotation mode.

