### PR TITLE
add fix for gamma control on IL9486 boards

### DIFF
--- a/TFT_Drivers/ILI9486_Init.h
+++ b/TFT_Drivers/ILI9486_Init.h
@@ -36,39 +36,47 @@
     writedata(0x00);
     writedata(0x00);
 
-    writecommand(0xE0);
-    writedata(0x0F);
-    writedata(0x1F);
-    writedata(0x1C);
-    writedata(0x0C);
-    writedata(0x0F);
-    writedata(0x08);
-    writedata(0x48);
-    writedata(0x98);
-    writedata(0x37);
-    writedata(0x0A);
-    writedata(0x13);
-    writedata(0x04);
-    writedata(0x11);
-    writedata(0x0D);
-    writedata(0x00);
- 
-    writecommand(0xE1);
-    writedata(0x0F);
-    writedata(0x32);
-    writedata(0x2E);
-    writedata(0x0B);
-    writedata(0x0D);
-    writedata(0x05);
-    writedata(0x47);
-    writedata(0x75);
-    writedata(0x37);
-    writedata(0x06);
-    writedata(0x10);
-    writedata(0x03);
-    writedata(0x24);
-    writedata(0x20);
-    writedata(0x00);
+    #if defined (TFT_PGAMCTRL_OFF)
+      // nill
+    #else
+      writecommand(0xE0);
+      writedata(0x0F);
+      writedata(0x1F);
+      writedata(0x1C);
+      writedata(0x0C);
+      writedata(0x0F);
+      writedata(0x08);
+      writedata(0x48);
+      writedata(0x98);
+      writedata(0x37);
+      writedata(0x0A);
+      writedata(0x13);
+      writedata(0x04);
+      writedata(0x11);
+      writedata(0x0D);
+      writedata(0x00);
+    #endif
+
+    #if defined (TFT_NGAMCTRL_OFF)
+      // nill
+    #else
+      writecommand(0xE1);
+      writedata(0x0F);
+      writedata(0x32);
+      writedata(0x2E);
+      writedata(0x0B);
+      writedata(0x0D);
+      writedata(0x05);
+      writedata(0x47);
+      writedata(0x75);
+      writedata(0x37);
+      writedata(0x06);
+      writedata(0x10);
+      writedata(0x03);
+      writedata(0x24);
+      writedata(0x20);
+      writedata(0x00);
+    #endif
  
     #if defined (TFT_PARALLEL_8_BIT) || defined (TFT_PARALLEL_16_BIT) || defined (RPI_DISPLAY_TYPE)
       writecommand(TFT_INVOFF);

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -116,6 +116,8 @@
 // #define TFT_INVERSION_ON
 // #define TFT_INVERSION_OFF
 
+// #define TFT_PGAMCTRL_OFF // Positive gamma control
+// #define TFT_NGAMCTRL_OFF // Negative gamma correction
 
 // ##################################################################################
 //


### PR DESCRIPTION
I've got this board: http://www.lcdwiki.com/4.0inch_SPI_Module_ILI9486 and have noticed issues with what appears to be the gamma correction set by default in the ILI9486 driver.  

When you use this board straight out of the box, R/G/B + black/white and the screen itself all display perfectly fine.  It is only when you go into the gradients and shades of colours that you notice they are not correct.  

My test code was along the lines of this loop:

 ` tft.fillScreen(0x8630); // 34352
  tft.setTextSize(1);
  tft.setTextFont(1);
  		
  int r=0,g=0,b=0;
  while (!killSwitch) {
    tft.setCursor(5, 5);
    tft.printf("r=%d,g=%d,b=%d",r,g,b);
    tft.fillRect(100, 100, 300, 200, ((r << 11) | (g << 5) | b));
    g++;
    if (g > 63) { r++; b++; g = r;  }
    if (r > 63) { r = 0; b = 0; }
    delay(100);
  }`

The datasheet for the chip: https://www.hpinfotech.ro/ILI9486.pdf which explains the E0 / E1 gamma control function.

As per this discussion: https://github.com/Bodmer/TFT_eSPI/discussions/3018, commenting out the gamma control commands makes my screen work perfectly.  

I would suggest as per this pull request if ILI9486_Init.h could take in config from User_Setup.h to make this control more explicit and probably save users time debugging not understanding the gamma control issue.  Hope this at least provides visibility on this fix and saves someone in the future a few hours of their day!