### PR TITLE
added support for SSD1333 160x128 OLED Display

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -59,6 +59,8 @@ menu "TFT_eSPI"
             bool "ST7796"
         config TFT_SSD1351_DRIVER
             bool "SSD1351"
+		config TFT_SSD1333_DRIVER
+            bool "SSD1333"
         config TFT_SSD1963_480_DRIVER
             bool "SSD1963_480"
         config TFT_SSD1963_800_DRIVER

--- a/TFT_Drivers/SSD1333_Defines.h
+++ b/TFT_Drivers/SSD1333_Defines.h
@@ -1,0 +1,26 @@
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH 160
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 128
+#endif
+
+#define TFT_SPI_MODE SPI_MODE0
+
+#define CGRAM_OFFSET
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0xE3
+#define TFT_SWRST   TFT_NOP
+#define TFT_CASET   0x15 // SETCOLUMN
+#define TFT_PASET   0x75 // SETROW
+#define TFT_RAMWR   0x5C // WRITERAM
+#define TFT_RAMRD   0x5D
+#define TFT_IDXRD   TFT_NOP
+#define TFT_INVOFF  0xA4 // NORMALDISPLAY
+#define TFT_INVON   0xA7 // INVERTDISPLAY
+#define TFT_DISPOFF 0xA6 // DISPLAYALLOFF
+#define TFT_DISPON  0xA5 // DISPLAYALLON

--- a/TFT_Drivers/SSD1333_Init.h
+++ b/TFT_Drivers/SSD1333_Init.h
@@ -1,0 +1,32 @@
+{
+  writecommand(0xFD); // COMMANDLOCK
+  writedata(0x12);
+  writecommand(0xAE); // DISPLAYOFF
+  writecommand(0xB3); // CLOCKDIV
+  writedata(0xD1);
+  writecommand(0xCA); // MUXRATIO
+  writedata(0x7F);
+  writecommand(0xA2); // DISPLAYOFFSET
+  writedata(0x30);
+  writecommand(0xA1); // STARTLINE
+  writedata(0x00);
+  writecommand(0xAD); // SETMASTER
+  writedata(0x80);
+  writecommand(0xC1); // CONTRASTABC
+  writedata(0x55);
+  writedata(0x5F);
+  writedata(0x90);
+  writecommand(0xC7); // CONTRASTMASTER MASTERCURRENT
+  writedata(0x0F);
+  writecommand(0xB9); // SETLINGRAYSCALE
+  writecommand(0xB1); // PHASELEN
+  writedata(0x22);
+  writecommand(0xBB); // PRECHARGEVOLT
+  writedata(0x17);
+  writecommand(0xB6); // PRECHARGEPERIOD
+  writedata(0x08);
+  writecommand(0xBE); // VCOMH
+  writedata(0x05);
+  writecommand(0xA6); // DISPLAYALLOFF
+  writecommand(0xAF); // DISPLAYON
+}

--- a/TFT_Drivers/SSD1333_Rotation.h
+++ b/TFT_Drivers/SSD1333_Rotation.h
@@ -1,0 +1,62 @@
+
+// This is the command sequence that rotates the SSD1333 driver coordinate frame
+
+rotation = m % 4; // Limit the range of values to 0-3
+
+uint8_t madctl = 0x64;
+uint8_t startline = 0x00;
+uint8_t dispoffset = 0x00;
+
+switch (rotation) {
+	case 0:
+		madctl |= 0x10;
+		_width = _init_width;
+		_height = _init_height;
+		startline = 0x00;
+		dispoffset = 0x30;
+		#ifdef CGRAM_OFFSET
+		colstart = 8;
+		rowstart = 0;
+		#endif
+		break;
+	case 1:
+		madctl |= 0x13;
+		_width = _init_height;
+		_height = _init_width;
+		startline = 0x00;
+		dispoffset = 0x30;
+		#ifdef CGRAM_OFFSET
+		colstart = 0;
+		rowstart = 8;
+		#endif
+		break;
+	case 2:
+		madctl |= 0x02;
+		_width = _init_width;
+		_height = _init_height;
+		startline = 0x30;
+		dispoffset = 0x80;
+		#ifdef CGRAM_OFFSET
+		colstart = 8;
+		rowstart = 48;
+		#endif
+		break;
+	case 3:
+		madctl |= 0x01;
+		_width = _init_height;
+		_height = _init_width;
+		startline = 0x00;
+		dispoffset = 0x80;
+		#ifdef CGRAM_OFFSET
+		colstart = 0;
+		rowstart = 8;
+		#endif
+		break;
+}
+
+writecommand(0xA0); // SETREMAP
+writedata(madctl);
+writecommand(0xA1); // STARTLINE
+writedata(startline);
+writecommand(0xA2); // DISPLAYOFFSET
+writedata(dispoffset);

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -80,6 +80,8 @@
     #define ILI9225_DRIVER
 #elif defined (CONFIG_TFT_GC9A01_DRIVER)
     #define GC9A01_DRIVER
+#elif defined (CONFIG_TFT_SSD1333_DRIVER)
+    #define SSD1333_DRIVER
 #endif
 
 #ifdef CONFIG_TFT_RGB_ORDER

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -769,6 +769,8 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Init.h"
 
+#elif defined (SSD1333_DRIVER)
+    #include "TFT_Drivers/SSD1333_Init.h"
 #endif
 
 #ifdef TFT_INVERSION_ON
@@ -870,6 +872,8 @@ void TFT_eSPI::setRotation(uint8_t m)
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Rotation.h"
 
+#elif defined (SSD1333_DRIVER)
+    #include "TFT_Drivers/SSD1333_Rotation.h"
 #endif
 
   delayMicroseconds(10);
@@ -3391,6 +3395,24 @@ void TFT_eSPI::setWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
     hw_write_masked(&spi_get_hw(SPI_X)->cr0, (16 - 1) << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS);
   #endif
 #elif defined (SSD1351_DRIVER)
+  if (rotation & 1) {
+    transpose(x0, y0);
+    transpose(x1, y1);
+  }
+  SPI_BUSY_CHECK;
+  DC_C; tft_Write_8(TFT_CASET);
+  DC_D; tft_Write_16(x1 | (x0 << 8));
+  DC_C; tft_Write_8(TFT_PASET);
+  DC_D; tft_Write_16(y1 | (y0 << 8));
+  DC_C; tft_Write_8(TFT_RAMWR);
+  DC_D;
+#elif defined (SSD1333_DRIVER)
+  #ifdef CGRAM_OFFSET
+    x0+=colstart;
+    x1+=colstart;
+    y0+=rowstart;
+    y1+=rowstart;
+  #endif
   if (rotation & 1) {
     transpose(x0, y0);
     transpose(x1, y1);

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -63,6 +63,7 @@
 //#define SSD1963_800ALT_DRIVER
 //#define ILI9225_DRIVER
 //#define GC9A01_DRIVER
+//#define SSD1333_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -137,6 +137,7 @@
 //#include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
 // #include <User_Setups/Setup212_LilyGo_T_PicoPro.h>         // For the LilyGo T-PICO-Pro with ST7796 222 x 480 TFT
 // #include <User_Setups/Setup213_LilyGo_T_Beam_Shield.h>         // For the LilyGo T-BEAM V1.x with ST7796 222 x 480 TFT
+// #include <User_Setups/Setup214_ESP32_SSD1333.h>         // Setup file for ESP32 and SSD1333 160x128 OLED
 
 //#include <User_Setups/Setup250_ESP32_S3_Box_Lite.h>      // For the ESP32 S3 Box Lite
 //#include <User_Setups/Setup251_ESP32_S3_Box.h>            // For the ESP32 S3 Box
@@ -271,7 +272,9 @@
 #elif defined (HX8357C_DRIVER)
      #include "TFT_Drivers/HX8357C_Defines.h"
      #define  TFT_DRIVER 0x835C
-
+#elif defined (SSD1333_DRIVER)
+     #include "TFT_Drivers/SSD1333_Defines.h"
+     #define  TFT_DRIVER 0x1333
                               // <<<<<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVER HERE
                               // XYZZY_init.h and XYZZY_rotation.h must also be added in TFT_eSPI.cpp
 #elif defined (XYZZY_DRIVER)

--- a/User_Setups/Setup214_ESP32_SSD1333.h
+++ b/User_Setups/Setup214_ESP32_SSD1333.h
@@ -1,0 +1,41 @@
+//                            USER DEFINED SETTINGS
+//   Set driver type, fonts to be loaded, pins used and SPI control method etc.
+//
+//   See the User_Setup_Select.h file if you wish to be able to define multiple
+//   setups and then easily select which setup file is used by the compiler.
+//
+//   If this file is edited correctly then all the library example sketches should
+//   run without the need to make any more changes for a particular hardware setup!
+//   Note that some sketches are designed for a particular TFT pixel width/height
+
+#define USER_SETUP_ID 214
+
+#define SSD1333_DRIVER
+
+#define TFT_MOSI 13 // In some display driver board, it might be written as "SDA" and so on.
+#define TFT_SCLK 14
+#define TFT_CS   15  // Chip select control pin
+#define TFT_DC   26  // Data Command control pin
+#define TFT_RST  27  // Reset pin (could connect to Arduino RESET pin)
+
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+// Comment out the #define below to stop the SPIFFS filing system and smooth font code being loaded
+// this will save ~20kbytes of FLASH
+#define SMOOTH_FONT
+
+#define SPI_FREQUENCY  10000000
+
+// The ESP32 has 2 free SPI ports i.e. VSPI and HSPI, the VSPI is the default.
+// If the VSPI port is in use and pins are not accessible (e.g. TTGO T-Beam)
+// then uncomment the following line:
+#define USE_HSPI_PORT
+//#define USE_VSPI_PORT


### PR DESCRIPTION
Added support for 1.69" RGB OLED Display (160x128) with _SSD1333_ controller from BuyDisplay
Tested with ESP32. 

[Product Page](https://www.buydisplay.com/color-1-69-inch-160x128-rgb-oled-display-panel-ssd1333-controller)
[Datasheet Display](https://www.buydisplay.com/download/manual/ER-OLED1.69-2C_Datasheet.pdf)
[Datasheet SSD1333](https://www.buydisplay.com/download/ic/SSD1333.pdf)
