### PR TITLE
Allowing -1 as a value for CONFIG_TFT_CS.

### DIFF
--- a/TFT_config.h
+++ b/TFT_config.h
@@ -132,9 +132,7 @@
 **                         Section 2: General Pin configuration
 ***************************************************************************************/
 // General pins
-#if CONFIG_TFT_CS == -1
-    #error "Invalid Chip Select pin. Check TFT_eSPI configuration"
-#else
+#ifdef CONFIG_TFT_CS
     #define TFT_CS          CONFIG_TFT_CS
 #endif
 
@@ -220,7 +218,7 @@
     #else
         #define TFT_D7      CONFIG_TFT_D7
     #endif
-    
+
     #if CONFIG_TFT_WR == -1
         #error "Invalid Write strobe pin. Check TFT_eSPI configuration"
     #else
@@ -260,7 +258,7 @@
     #if CONFIG_TFT_SPI_READ_FREQ != -1
         #define SPI_READ_FREQUENCY CONFIG_TFT_SPI_READ_FREQ
     #endif
-    
+
     #ifdef CONFIG_TFT_SDA_READ
         #define TFT_SDA_READ
     #endif


### PR DESCRIPTION
### Context
When the library get configured using the `idf.py menuconfig` tool(the TFT_eSPI lib used as an ESP-IDF component), the `CONFIG_TFT_CS` config is used for setting the `CS` pin. However a check exists in the `TFT_config.h` file that raises an error if the value of `CONFIG_TFT_CS` is `-1`, this check should be removed since `-1` as a value is allowed by the library itself[[1](https://github.com/Bodmer/TFT_eSPI/blob/fae22f785f8b4f7970195487826a348d08d082ae/TFT_eSPI.cpp#L536), [2](https://github.com/Bodmer/TFT_eSPI/blob/fae22f785f8b4f7970195487826a348d08d082ae/Kconfig#L294)] to allow disabling the automatic control of the `CS` pin which is needed in some cases like controlling [more than one screen](https://github.com/Bodmer/TFT_eSPI/blob/fae22f785f8b4f7970195487826a348d08d082ae/examples/Generic/Animated_Eyes_2/wiring.ino#L4).

