### PR TITLE
Add support for NV3030B TFT Controller Driver

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -69,9 +69,11 @@ menu "TFT_eSPI"
             bool "ILI9225"
         config TFT_GC9A01_DRIVER
             bool "GC9A01"
+        config TFT_NV3030B_DRIVER
+            bool "NV3030B"			
     endchoice
 
-    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9341_DRIVER || TFT_ILI9341_2_DRIVER
+    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9341_DRIVER || TFT_ILI9341_2_DRIVER || TFT_NV3030B_DRIVER
         choice TFT_COLOR_ORDER
             prompt "Define the colour order"
             help
@@ -90,7 +92,7 @@ menu "TFT_eSPI"
         help
             Enable if using M5Stack module with integrated ILI9341
 
-    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9163_DRIVER || TFT_GC9A01_DRIVER
+    if TFT_ST7735_DRIVER || TFT_ST7789_DRIVER || TFT_ST7789_2_DRIVER || TFT_ILI9163_DRIVER || TFT_GC9A01_DRIVER || TFT_NV3030B_DRIVER
         config TFT_WIDTH
             int "LCD pixel width in portrait orientation"
             default 128

--- a/TFT_Drivers/NV3030B_Defines.h
+++ b/TFT_Drivers/NV3030B_Defines.h
@@ -1,0 +1,110 @@
+// Change the width and height if required (defined in portrait mode)
+// or use the constructor to over-ride defaults
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH  240
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 320
+#endif
+
+// 1.83" Round Rectangle Color IPS TFT Display
+#if (TFT_HEIGHT == 280) && (TFT_WIDTH == 240)
+  #ifndef CGRAM_OFFSET
+    #define CGRAM_OFFSET
+  #endif
+#endif
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+#define TFT_NORON   0x13
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+#define TFT_RAMRD   0x2E
+#define TFT_MADCTL  0x36
+
+// Flags for TFT_MADCTL
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+
+#ifdef TFT_RGB_ORDER
+  #if (TFT_RGB_ORDER == 1)
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #endif
+#else
+  #ifdef CGRAM_OFFSET
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #endif
+#endif
+
+// All NV3030B specific commands some are used by init()
+#define NV3030B_NOP 	0x00     // No-op register
+#define NV3030B_SWRESET	0x01     // Software reset (NV3030A only)
+
+#define NV3030B_RDDID 0x04   // Read display identification information
+#define NV3030B_RDDST 0x09   // Read Display Status
+
+#define NV3030B_SLPIN 0x10  // Enter Sleep Mode
+#define NV3030B_SLPOUT 0x11 // Sleep Out
+#define NV3030B_PTLON 0x12  // Partial Mode ON
+#define NV3030B_NORON 0x13  // Normal Display Mode ON and Partial Mode OFF
+
+#define NV3030B_RDMODE 0x0A     // Read Display Power Mode
+#define NV3030B_RDMADCTL 0x0B   // Read Display MADCTL
+#define NV3030B_RDPIXFMT 0x0C   // Read Display Pixel Format
+#define NV3030B_RDIMGMODE 0x0D  // Read Display Image Mode
+#define NV3030B_RDSIGNMODE 0x0E // Read Display Signal mode
+#define NV3030B_RDSELFDIAG 0x0F // Read Display Self-Diagnostic Result
+
+#define NV3030B_INVOFF 0x20   // Display Inversion OFF
+#define NV3030B_INVON 0x21    // Display Inversion ON
+#define NV3030B_DISPOFF 0x28  // Display OFF
+#define NV3030B_DISPON 0x29   // Display ON
+
+#define NV3030B_CASET 0x2A  // Column Address Set
+#define NV3030B_PASET 0x2B  // Page Address Set
+#define NV3030B_RAMWR 0x2C  // Memory Write
+#define NV3030B_RAMRD 0x2E  // Memory Read (NV3030A only)
+
+#define NV3030B_PTLAR 0x30    // Partial Area
+#define NV3030B_VSCRDEF 0x33  // Vertical Scrolling Definition
+#define NV3030B_TEOFF 0x34    // Tearing effect line off
+#define NV3030B_TEON 0x35     // Tearing effect line on
+#define NV3030B_MADCTL 0x36   // Memory Access Control
+#define NV3030B_VSCRSADD 0x37 // Vertical Scrolling Start Address
+#define NV3030B_IDLEOFF 0x38  // Idle mode off
+#define NV3030B_IDLEON 0x39   // Idle mode on and other mode off
+
+#define NV3030B_PIXFMT 0x3A    // Interface Pixel Format
+#define NV3030B_RAMWRCNT 0x3C  // Write memory continue
+#define NV3030B_RAMRDCNT 0x3E  // Read memory continue (NV3030A only)
+#define NV3030B_TESCANSET 0x44 // Set tear scanline
+#define NV3030B_TESCANGET 0x45 // Get tear scanline
+#define NV3030B_WRDISBV 0x53   // Write display brightness (NV3030B only)
+#define NV3030B_RDDISBV 0x54   // Read display brightness (NV3030B only)
+
+#define NV3030B_RDIDD3 0xD3 // Read idd3
+#define NV3030B_RDID1 0xDA  // Read display ID 1
+#define NV3030B_RDID2 0xDB  // Read display ID 2
+#define NV3030B_RDID3 0xDC  // Read display ID 3

--- a/TFT_Drivers/NV3030B_Init.h
+++ b/TFT_Drivers/NV3030B_Init.h
@@ -1,0 +1,51 @@
+
+// This is the command sequence that initialises the NV3030B driver
+
+// Configure NV3030B display
+{
+static const uint8_t PROGMEM
+  nv3030b[] = {
+	  32,
+	  0xFD, 2, 0x06, 0x08,                                     // 1: Enter read/write private register, 2 args
+	  0x61, 2, 0x07, 0x04,                                     // 2: dvdd setting, 2 args	  
+	  0x62, 4, 0x00, 0x44, 0x40, 0x00,                         // 3: bias setting, 4 args
+	  0x63, 4, 0x41, 0x07, 0x12, 0x12,                         // 4: vgl setting, 4 args
+	  0x64, 1, 0x37,                                           // 5: vgh setting, 1 arg
+	  0x65, 3, 0x09, 0x10, 0x21,                               // 6: VSP, 3 args
+	  0x66, 3, 0x09, 0x10, 0x21,                               // 7: VSN, 3 args
+	  0x67, 2, 0x20, 0x40,                                     // 8: pump clock set, 2 args
+	  0x68, 4, 0x90, 0x4C, 0x7C, 0x06,                         // 9: gamma ref 1, 4 args
+	  0xB1, 3, 0x0F, 0x02, 0x01,                               // 10: frame rate, 3 args
+	  0xB4, 1, 0x01,                                           // 11: display pol control, 1 arg
+	  0xB5, 4, 0x02, 0x02, 0x0A, 0x14,                         // 12: blanking porch, 4 args
+	  0xB6, 5, 0x04, 0x01, 0x9F, 0x00, 0x02,                   // 13: display function, 5 args
+	  0xDF, 1, 0x11,                                           // 14: gofc_gamma_en_sel=1, 1 arg
+	  0xE2, 6, 0x03, 0x00, 0x00, 0x26, 0x27, 0x3F,             // 15: gamma positive 3, 6 args
+	  0xE5, 6, 0x3F, 0x27, 0x26, 0x00, 0x00, 0x03,             // 16: gamma negative 3, 6 args
+	  0xE1, 2, 0x00, 0x57,                                     // 17: gamma positive 2, 2 args
+	  0xE4, 2, 0x58, 0x00,                                     // 18: gamma negative 2, 2 args
+	  0xE0, 8, 0x01, 0x03, 0x0D, 0x0E, 0x0E, 0x0C, 0x15, 0x19, // 19: gamma positive 1, 8 args
+	  0xE3, 8, 0x1A, 0x16, 0x0C, 0x0F, 0x0E, 0x0D, 0x02, 0x01, // 20: gamma negative 1, 8 args
+	  0xE6, 2, 0x00, 0xFF,                                     // 21: SRC_CTRL1, 2 args
+	  0xE7, 6, 0x01, 0x04, 0x03, 0x03, 0x00, 0x12,             // 22: SRC_CTRL2, 6 args
+	  0xE8, 3, 0x00, 0x70, 0x00,                               // 23: SRC_CTRL3, 3 args
+	  0xEC, 1, 0x52,                                           // 24: Gate driver timing, 1 arg
+	  0xF1, 3, 0x01, 0x01, 0x02,                               // 25: tearing effect, 3 args
+	  0xF6, 4, 0x09, 0x10, 0x00, 0x00,                         // 26: interface control, 4 args
+	  0xFD, 2, 0xFA, 0xFC,                                     // 27: exit read/write private register, 2 args
+	  NV3030B_PIXFMT, 1, 0x55,                                 // 28: set 16bit/pixel format
+	  NV3030B_MADCTL, 1, TFT_MAD_BGR,                          // 29: set BGR order
+	  NV3030B_INVON, 0,                                        // 30: Inversion on, no args, no delay
+	  NV3030B_SLPOUT, TFT_INIT_DELAY, 120,                     // 31: Exit sleep, no args, delay 120ms
+	  NV3030B_DISPON, TFT_INIT_DELAY, 10                       // 32: Display on, no args, delay 10ms
+    };
+
+  commandList(nv3030b);
+
+  #ifdef TFT_BL
+  // Turn on the back-light LED
+  digitalWrite(TFT_BL, HIGH);
+  pinMode(TFT_BL, OUTPUT);
+  #endif
+}
+// End of NV3030B display configuration

--- a/TFT_Drivers/NV3030B_Rotation.h
+++ b/TFT_Drivers/NV3030B_Rotation.h
@@ -1,0 +1,80 @@
+  // This is the command sequence that rotates the NV3030B driver coordinate frame
+
+  writecommand(TFT_MADCTL);
+  rotation = m % 4;
+  switch (rotation) {
+    case 0: // Portrait
+#ifdef CGRAM_OFFSET
+      if(_init_height == 280)
+      {
+        colstart = 0;
+        rowstart = 20;
+      }
+      else
+      {
+        colstart = 0;
+        rowstart = 0;
+      }
+#endif
+      writedata(TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_width;
+      _height = _init_height;
+      break;
+
+    case 1: // Landscape (Portrait + 90)
+#ifdef CGRAM_OFFSET
+      if(_init_height == 280)
+      {
+        colstart = 20;
+        rowstart = 0;
+      }
+      else
+      {
+        colstart = 0;
+        rowstart = 0;
+      }
+#endif
+      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_height;
+      _height = _init_width;
+      break;
+
+      case 2: // Inverter portrait
+#ifdef CGRAM_OFFSET
+      if(_init_height == 280)
+      {
+        colstart = 0;
+        rowstart = 20;
+      }
+      else
+      {
+        colstart = 0;
+        rowstart = 80;
+      }
+#endif
+      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_width;
+      _height = _init_height;
+       break;
+    case 3: // Inverted landscape
+#ifdef CGRAM_OFFSET
+      if(_init_height == 280)
+      {
+        colstart = 20;
+        rowstart = 0;
+      }
+      else
+      {
+        colstart = 80;
+        rowstart = 0;
+      }
+#endif
+      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+
+      _width  = _init_height;
+      _height = _init_width;
+      break;
+  }

--- a/TFT_config.h
+++ b/TFT_config.h
@@ -80,6 +80,8 @@
     #define ILI9225_DRIVER
 #elif defined (CONFIG_TFT_GC9A01_DRIVER)
     #define GC9A01_DRIVER
+#elif defined (CONFIG_TFT_NV3030B_DRIVER)
+    #define NV3030B_DRIVER
 #endif
 
 #ifdef CONFIG_TFT_RGB_ORDER

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -769,6 +769,9 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Init.h"
 
+#elif defined (NV3030B_DRIVER)
+    #include "TFT_Drivers/NV3030B_Init.h"
+
 #endif
 
 #ifdef TFT_INVERSION_ON
@@ -869,6 +872,9 @@ void TFT_eSPI::setRotation(uint8_t m)
 
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Rotation.h"
+	
+#elif defined (NV3030B_DRIVER)
+    #include "TFT_Drivers/NV3030B_Rotation.h"
 
 #endif
 

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -63,6 +63,7 @@
 //#define SSD1963_800ALT_DRIVER
 //#define ILI9225_DRIVER
 //#define GC9A01_DRIVER
+//#define NV3030B_DRIVER
 
 // Some displays support SPI reads via the MISO pin, other displays have a single
 // bi-directional SDA pin and the library will try to read this via the MOSI line.

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -271,6 +271,9 @@
 #elif defined (HX8357C_DRIVER)
      #include "TFT_Drivers/HX8357C_Defines.h"
      #define  TFT_DRIVER 0x835C
+#elif defined (NV3030B_DRIVER)
+     #include "TFT_Drivers/NV3030B_Defines.h"
+     #define  TFT_DRIVER 0x3030
 
                               // <<<<<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVER HERE
                               // XYZZY_init.h and XYZZY_rotation.h must also be added in TFT_eSPI.cpp


### PR DESCRIPTION
NV3030B TFT Controller library based on ST7789 code:
- **NV3030B_Defines.h**: added NV3030B specific commands (based on NV3030A/NV3030B datasheets)
- **NV3030B_Init.h**: added initialization command from from examples found on buydisplay/github
- **NV3030B_Rotation.h**: removed not supported display resolutions (since displays are only available with a resolution of 240x280)


[NV3030B.pdf](https://github.com/Bodmer/TFT_eSPI/files/15256000/NV3030B.pdf)
[NV3030A.pdf](https://github.com/Bodmer/TFT_eSPI/files/15256001/NV3030A.pdf)
