### PR TITLE
Expose current TextWrap settings via getTextWrap(), getTextWrapX(), and getTextWrapY()

### DIFF
--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -2983,6 +2983,23 @@ void TFT_eSPI::setTextWrap(bool wrapX, bool wrapY)
   textwrapY = wrapY;
 }
 
+/***************************************************************************************
+** Function name:           getTextWrapX
+** Description:             Returns current text wrap width setting
+***************************************************************************************/
+bool TFT_eSPI::getTextWrapX() {
+  return textwrapX;
+}
+
+
+/***************************************************************************************
+** Function name:           getTextWrapY
+** Description:             Returns current text wrap height setting
+***************************************************************************************/
+bool TFT_eSPI::getTextWrapY() {
+  return textwrapY;
+}
+
 
 /***************************************************************************************
 ** Function name:           setTextDatum

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -2990,6 +2990,9 @@ void TFT_eSPI::setTextWrap(bool wrapX, bool wrapY)
 bool TFT_eSPI::getTextWrapX() {
   return textwrapX;
 }
+bool TFT_eSPI::getTextWrap() {
+  return textwrapX;
+}
 
 
 /***************************************************************************************

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -662,6 +662,9 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
            setTextSize(uint8_t size);                       // Set character size multiplier (this increases pixel size)
 
   void     setTextWrap(bool wrapX, bool wrapY = false);     // Turn on/off wrapping of text in TFT width and/or height
+  bool     getTextWrapX();                                  // get current textwrap setting for width
+  bool     getTextWrapY();                                  // get current textwrap setting for height
+
 
   void     setTextDatum(uint8_t datum);                     // Set text datum position (default is top left), see Section 5 above
   uint8_t  getTextDatum(void);

--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -663,6 +663,7 @@ class TFT_eSPI : public Print { friend class TFT_eSprite; // Sprite class has ac
 
   void     setTextWrap(bool wrapX, bool wrapY = false);     // Turn on/off wrapping of text in TFT width and/or height
   bool     getTextWrapX();                                  // get current textwrap setting for width
+  bool     getTextWrap();                                   // get current textwrap setting for width (to match some other graphics libraries)
   bool     getTextWrapY();                                  // get current textwrap setting for height
 
 


### PR DESCRIPTION
In my project I needed to disable TextWrap and then restore it to the original state, but the textwrap flags aren't exposed publicly.  

This patch adds public getTextWrapY() and getTextWrapX() methods to allow checking of the current TextWrap state.  

Also adds getTextWrap() as an alias for getTextWrapX(), to make the API match the ili9341_t3n library more closely.

Hope this is useful to other people too!