### PR TITLE
Remove HMI gram offset

### DIFF
--- a/User_Setups/Setup207_LilyGo_T_HMI.h
+++ b/User_Setups/Setup207_LilyGo_T_HMI.h
@@ -8,7 +8,7 @@
 #define TFT_WIDTH 240
 #define TFT_HEIGHT 320
 
-#define CGRAM_OFFSET
+// #define CGRAM_OFFSET
 // #define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
 #define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
 


### PR DESCRIPTION
T-HMI needs to remove the coordinate offset to display properly 
https://github.com/Xinyuan-LilyGO/T-HMI/issues/7