### PR TITLE
Add support for WT32-SC01 Plus module

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -124,13 +124,18 @@ void TFT_eSPI::busDir(uint32_t mask, uint8_t mode)
 {
   // Arduino generic native function
   pinMode(TFT_D0, mode);
-  pinMode(TFT_D1, mode);
+  #if !defined (WT32_SC01_PLUS)
+    pinMode(TFT_D1, mode);
+  #else
+    pinMode(46, mode);
+  #endif
   pinMode(TFT_D2, mode);
   pinMode(TFT_D3, mode);
   pinMode(TFT_D4, mode);
   pinMode(TFT_D5, mode);
   pinMode(TFT_D6, mode);
   pinMode(TFT_D7, mode);
+  
 }
 
 /***************************************************************************************

--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -387,7 +387,11 @@ SPI3_HOST = 2
       #define GPIO_OUT_CLR_MASK (GPIO_DIR_MASK | (1 << (TFT_WR-32)))
     #elif (TFT_D0 >= 0)
       // Data bits and the write line are cleared sequentially
-      #define GPIO_OUT_CLR_MASK (GPIO_DIR_MASK); WR_L
+      #if defined (WT32_SC01_PLUS)
+        #define GPIO_OUT_CLR_MASK (GPIO_DIR_MASK); WR_L | (1 << (14))
+      #else
+        #define GPIO_OUT_CLR_MASK (GPIO_DIR_MASK); WR_L
+      #endif
     #endif
   #elif (TFT_WR >= 0)
     #if (TFT_D0 >= 32)
@@ -410,7 +414,11 @@ SPI3_HOST = 2
   //*/
 
   // Write 8 bits to TFT
-  #define tft_Write_8(C)  GPIO_CLR_REG =  GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t)(C)); WR_H
+  #if defined (WT32_SC01_PLUS)
+    #define tft_Write_8(C)  GPIO_CLR_REG =  GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t)(C)); GPIO.out1_w1ts.val = set_mask((uint8_t)(C)) & (1 << (14)); WR_H
+  #else
+    #define tft_Write_8(C)  GPIO_CLR_REG =  GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t)(C)); WR_H
+  #endif
 
   #if defined (SSD1963_DRIVER)
 
@@ -430,33 +438,64 @@ SPI3_HOST = 2
       #define tft_Write_16S(C) GPIO.out_w1tc = GPIO_OUT_CLR_MASK; GPIO.out_w1ts = set_mask((uint8_t) ((C) >> 8)); WR_H
     #else
       // Write 16 bits to TFT
-      #define tft_Write_16(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
-                              GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H
+      #if defined (WT32_SC01_PLUS)
+        #define tft_Write_16(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H; \
+                                GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H
+      #else
+        #define tft_Write_16(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
+                                GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H
+      #endif                        
 
       // 16-bit write with swapped bytes
-      #define tft_Write_16S(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
-                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H
+      #if defined (WT32_SC01_PLUS)
+        #define tft_Write_16S(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H; \
+                                 GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H
+      #else
+        #define tft_Write_16S(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
+                                 GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H
+      #endif                    
     #endif
 
   #endif
 
   // Write 32 bits to TFT
-  #define tft_Write_32(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 24)); WR_H; \
-                          GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 16)); WR_H; \
-                          GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  8)); WR_H; \
-                          GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  0)); WR_H
+  #if defined (WT32_SC01_PLUS)
+    #define tft_Write_32(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 24)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 24)) & (1 << (14)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 16)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 16)) & (1 << (14)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H
+  #else
+    #define tft_Write_32(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 24)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 16)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  8)); WR_H; \
+                            GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >>  0)); WR_H                          
+  #endif
 
   // Write two concatenated 16-bit values to TFT
-  #define tft_Write_32C(C,D) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
-                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
-                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 8)); WR_H; \
-                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 0)); WR_H
+  #if defined (WT32_SC01_PLUS)
+    #define tft_Write_32C(C,D) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((D) >> 8)) & (1 << (14)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((D) >> 0)) & (1 << (14)); WR_H
+  #else
+    #define tft_Write_32C(C,D) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 8)); WR_H; \
+                               GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((D) >> 0)); WR_H
+  #endif
 
   // Write 16-bit value twice to TFT - used by drawPixel()
-  #define tft_Write_32D(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
-                           GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
-                           GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
-                           GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H
+  #if defined (WT32_SC01_PLUS)
+    #define tft_Write_32D(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 8)) & (1 << (14)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); GPIO.out1_w1ts.val = set_mask((uint8_t) ((C) >> 0)) & (1 << (14)); WR_H
+  #else
+    #define tft_Write_32D(C) GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 8)); WR_H; \
+                             GPIO_CLR_REG = GPIO_OUT_CLR_MASK; GPIO_SET_REG = set_mask((uint8_t) ((C) >> 0)); WR_H
+  #endif
 
    // Read pin
   #ifdef TFT_RD

--- a/TFT_Drivers/ST7796_Init.h
+++ b/TFT_Drivers/ST7796_Init.h
@@ -46,6 +46,17 @@
 	writedata(0x19);    //Timing for "Gate start"=25 (Tclk)
 	writedata(0xA5);    //Timing for "Gate End"=37 (Tclk), Gate driver EQ function ON
 	writedata(0x33);
+
+#if defined (WT32_SC01_PLUS)
+ 	writecommand(0xB1); //Frame Rate
+    writedata(0xB0);
+    writedata(0x02); 
+ 
+ 	writecommand(0xB5); //Frame Rate
+    writedata(0x02);
+    writedata(0x02);
+    writedata(0x04); 
+#endif
 	
 	writecommand(0xC1); //Power control2                          
 	writedata(0x06);    //VAP(GVDD)=3.85+( vcom+vcom offset), VAN(GVCL)=-3.85+( vcom+vcom offset)

--- a/TFT_Drivers/ST7796_Rotation.h
+++ b/TFT_Drivers/ST7796_Rotation.h
@@ -30,7 +30,11 @@
 #endif
       break;
     case 2:
+#if defined (WT32_SC01_PLUS)
+      writedata(TFT_MAD_MY | TFT_MAD_COLOR_ORDER | TFT_MAD_ML);
+#else
       writedata(TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+#endif
       _width  = _init_width;
       _height = _init_height;
 #ifdef CGRAM_OFFSET

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -587,6 +587,9 @@ void TFT_eSPI::initBus(void) {
     pinMode(TFT_D5, OUTPUT); digitalWrite(TFT_D5, HIGH);
     pinMode(TFT_D6, OUTPUT); digitalWrite(TFT_D6, HIGH);
     pinMode(TFT_D7, OUTPUT); digitalWrite(TFT_D7, HIGH);
+    #if defined (WT32_SC01_PLUS)
+    pinMode(46, OUTPUT); digitalWrite(46, HIGH);
+    #endif
   #endif
 
   PARALLEL_INIT_TFT_DATA_BUS;
@@ -6155,4 +6158,3 @@ void TFT_eSPI::getSetup(setup_t &tft_settings)
   #include "Extensions/AA_graphics.cpp"  // Loaded if SMOOTH_FONT is defined by user
 #endif
 ////////////////////////////////////////////////////////////////////////////////////////
-

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -137,6 +137,7 @@
 //#include <User_Setups/Setup211_LilyGo_T_QT_Pro_S3.h>         // For the LilyGo T-QT Pro S3 based ESP32S3 with GC9A01 128 x 128 TFT
 // #include <User_Setups/Setup212_LilyGo_T_PicoPro.h>         // For the LilyGo T-PICO-Pro with ST7796 222 x 480 TFT
 // #include <User_Setups/Setup213_LilyGo_T_Beam_Shield.h>         // For the LilyGo T-BEAM V1.x with ST7796 222 x 480 TFT
+// #include <User_Setups/Setup214_WT32_SC01_Plus.h>         // For the WT32-SC01 Plus Module
 
 //#include <User_Setups/Setup250_ESP32_S3_Box_Lite.h>      // For the ESP32 S3 Box Lite
 //#include <User_Setups/Setup251_ESP32_S3_Box.h>            // For the ESP32 S3 Box

--- a/User_Setups/Setup214_WT32_SC01_Plus.h
+++ b/User_Setups/Setup214_WT32_SC01_Plus.h
@@ -1,0 +1,58 @@
+// This setup is for the WT32-SC01 Plus Module
+// See SetupX_Template.h for all options available
+#define USER_SETUP_ID 214
+
+////////////////////////////////////////////////////////////////////////////////////////////
+// Interface
+////////////////////////////////////////////////////////////////////////////////////////////
+#define ESP32_PARALLEL
+#define WT32_SC01_PLUS
+////////////////////////////////////////////////////////////////////////////////////////////
+// Display driver type
+////////////////////////////////////////////////////////////////////////////////////////////
+#define ST7796_DRIVER
+
+////////////////////////////////////////////////////////////////////////////////////////////
+// WT32-SC01 Plus
+////////////////////////////////////////////////////////////////////////////////////////////
+
+#define TFT_INVERSION_ON
+#define TFT_ROTATION_ON
+
+//#define TFT_CS   -1  // Do not define, chip select control pin permanently connected to 0V
+
+// These pins can be moved and are controlled directly by the library software
+#define TFT_DC   0    // Data Command control pin
+#define TFT_RST   4    // Reset pin
+#define TFT_BL  45   //Backlight
+
+#define TFT_RD   -1  // Do not define, read pin permanently connected to 3V3
+
+// Note: All the following pins are PIO hardware configured and driven
+#define TFT_WR   47
+
+  // PIO requires these to be sequentially increasing - do not change
+#define TFT_D0    9
+#define TFT_D1    14
+#define TFT_D2    3
+#define TFT_D3    8
+#define TFT_D4   18
+#define TFT_D5   17
+#define TFT_D6   16
+#define TFT_D7   15
+//*/
+
+////////////////////////////////////////////////////////////////////////////////////////////
+// Fonts to be available
+////////////////////////////////////////////////////////////////////////////////////////////
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+////////////////////////////////////////////////////////////////////////////////////////////

--- a/User_Setups/Setup214_WT32_SC01_Plus.h
+++ b/User_Setups/Setup214_WT32_SC01_Plus.h
@@ -18,6 +18,7 @@
 
 #define TFT_INVERSION_ON
 #define TFT_ROTATION_ON
+#define TFT_BACKLIGHT_ON HIGH
 
 //#define TFT_CS   -1  // Do not define, chip select control pin permanently connected to 0V
 


### PR DESCRIPTION
These changes add support for the WT32-SC01 Plus module. The main problem with this module is, that the 8 data bits are spread across two registers which is not ideal in terms of performance. The change implements support with as little performance penalty possible. In order to enable support the symbol WT32_SC01_PLUS needs to be defined (see User_Setups/ Setup214_WT32_SC01_Plus.h).