### PR TITLE
Add User Setup for M5Dial Esp32 GC9A01

### DIFF
--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -144,6 +144,8 @@
 //#include <User_Setups/Setup301_BW16_ST7735.h>            // Setup file for Bw16-based boards with ST7735 160 x 80 TFT
 //#include <User_Setups/Setup302_Waveshare_ESP32S3_GC9A01.h>            // Setup file for Waveshare ESP32-S3-Touch-LCD-1.28 board with GC9A01 240*240 TFT
 
+//#include <User_Setups/Setup303_M5Dial_ESP32S3_GC9A01.h> // Setup file for M5Dial board with ESP32-S3 and GC9A01 240*240 TFT
+
 //#include <User_Setups/SetupX_Template.h>     // Template file for a setup
 
 

--- a/User_Setups/Setup303_M5Dial_ESP32S3_GC9A01.h
+++ b/User_Setups/Setup303_M5Dial_ESP32S3_GC9A01.h
@@ -1,0 +1,30 @@
+// See SetupX_Template.h for all options available
+#define USER_SETUP_ID 303
+
+#define GC9A01_DRIVER
+
+#define TFT_MISO -1
+#define TFT_MOSI 5 
+#define TFT_SCLK 6
+#define TFT_CS 7 
+#define TFT_DC 4 
+#define TFT_RST 8 
+#define TFT_BL 9 
+#define TFT_BACKLIGHT_ON HIGH
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+#define SMOOTH_FONT
+
+#define TFT_WIDTH 240
+#define TFT_HEIGHT 240
+
+#define SPI_FREQUENCY  80000000
+
+#define USE_HSPI_PORT
+//#define SUPPORT_TRANSACTIONS


### PR DESCRIPTION
I add the User setup for M5 Dial
i also add #define USE_HSPI_PORT for use with Arduino IDF 3.0.0
So much people struck with lack of this define when working with esp32s3 3.0.0