### PR TITLE
Fix Boot Loop on ESP32S3 Due to Mis-defined SPI Port

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -80,7 +80,7 @@ SPI3_HOST = 2
   #elif CONFIG_IDF_TARGET_ESP32S2
     #define SPI_PORT 2 //FSPI(ESP32 S2)
   #elif CONFIG_IDF_TARGET_ESP32S3
-    #define SPI_PORT FSPI
+    #define SPI_PORT 3
   #endif
 #endif
 


### PR DESCRIPTION
People have been having trouble using SPI on ESP32 S3. Here are a couple of related discussions:
https://github.com/Bodmer/TFT_eSPI/discussions/3283
https://github.com/espressif/arduino-esp32/issues/10254

The ESP IDF code indicates that only SPI 2 and 3 should be used. See: https://github.com/espressif/esp-idf/blob/9b3eda09741b5c7dae8f22fe60d193dcc3a7ec44/components/soc/esp32s3/include/soc/soc.h#L37

When `SPI_PORT` is defined to `FSPI`, the ESP Arduino framework defines it to `0`. https://github.com/espressif/arduino-esp32/blob/7018cd114d00249674567846c9d67fbb3a1240a3/cores/esp32/esp32-hal-spi.h#L32

Using `0` with `REG_SPI_BASE` in ESP IDF soc.h returns NULL, which causes all subsequent SPI actions to hard-fault.

The simplest solution is to not define `SPI_PORT` to `FSPI`, but rather to GSPI2 or GPSI3 by default, as these are supported by the ESP IDF.