### PR TITLE
Add support for LilyGO T-Dongle.

### DIFF
--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -118,6 +118,8 @@
 
 //#include <User_Setups/Setup138_Pico_Explorer_Base_RP2040_ST7789.h> // Setup file for Pico Explorer Base by Pimoroni for RP2040 (ST7789 on SPI bus with 240x240 TFT)
 
+//#include <User_Setups/Setup139_LilyGo_TDongle.h>           // Setup file for ESP8266 and ST7789 135 x 240 TFT on LilyGo T-Dongle [not T-Dongle S3].
+
 //#include <User_Setups/Setup200_GC9A01.h>           // Setup file for ESP32 and GC9A01 240 x 240 TFT
 
 //#include <User_Setups/Setup201_WT32_SC01.h>        // Setup file for ESP32 based WT32_SC01 from Seeed

--- a/User_Setups/Setup139_LilyGo_TDongle.h
+++ b/User_Setups/Setup139_LilyGo_TDongle.h
@@ -1,0 +1,41 @@
+// ST7789 135 x 240 display with no chip select line
+
+#define ST7789_DRIVER     // Configure all registers
+
+#define TFT_WIDTH  135
+#define TFT_HEIGHT 240
+
+#define CGRAM_OFFSET      // Library will add offsets required
+
+//#define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+//#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
+//#define TFT_INVERSION_ON
+//#define TFT_INVERSION_OFF
+
+// LilyGo T-Dongle [esp32s2]
+#define TFT_MISO 4
+#define TFT_MOSI 35
+#define TFT_SCLK 36
+#define TFT_CS 34  // Chip select control pin
+#define TFT_DC 37  // Data Command control pin
+#define TFT_RST 38 // Reset pin (could connect to RST pin)
+
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+//#define LOAD_FONT8N // Font 8. Alternative to Font 8 above, slightly narrower, so 3 digits fit a 160 pixel TFT
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+
+#define SMOOTH_FONT
+
+
+#define SPI_FREQUENCY  40000000
+
+#define SPI_READ_FREQUENCY  20000000
+
+#define SPI_TOUCH_FREQUENCY  2500000


### PR DESCRIPTION
This adopts the settings found in the original repository of the LilyGO T-Dongle [https://github.com/Xinyuan-LilyGO/T-Dongle-ESP32S2/blob/c8f6b39810cd4a8845490f1c102cc235c80078d5/lib/TFT_eSPI/User_Setups/Setup135_ST7789.h] in its own file for easier reusability.