### PR TITLE
Xiao nRF52840 with a ST7735S

### DIFF
--- a/User_Setup.h
+++ b/User_Setup.h
@@ -42,9 +42,9 @@
 //#define RPI_DISPLAY_TYPE // 20MHz maximum SPI
 
 // Only define one driver, the other ones must be commented out
-#define ILI9341_DRIVER       // Generic driver for common displays
+//#define ILI9341_DRIVER       // Generic driver for common displays
 //#define ILI9341_2_DRIVER     // Alternative ILI9341 driver, see https://github.com/Bodmer/TFT_eSPI/issues/1172
-//#define ST7735_DRIVER      // Define additional parameters below for this display
+#define ST7735_DRIVER      // Define additional parameters below for this display
 //#define ILI9163_DRIVER     // Define additional parameters below for this display
 //#define S6D02A1_DRIVER
 //#define RPI_ILI9486_DRIVER // 20MHz maximum SPI
@@ -82,15 +82,15 @@
 
 // For ST7789, ST7735, ILI9163 and GC9A01 ONLY, define the pixel width and height in portrait orientation
 // #define TFT_WIDTH  80
-// #define TFT_WIDTH  128
+#define TFT_WIDTH  128
 // #define TFT_WIDTH  172 // ST7789 172 x 320
 // #define TFT_WIDTH  170 // ST7789 170 x 320
 // #define TFT_WIDTH  240 // ST7789 240 x 240 and 240 x 320
-// #define TFT_HEIGHT 160
+#define TFT_HEIGHT 160
 // #define TFT_HEIGHT 128
 // #define TFT_HEIGHT 240 // ST7789 240 x 240
 // #define TFT_HEIGHT 320 // ST7789 240 x 320
-// #define TFT_HEIGHT 240 // GC9A01 240 x 240
+// #define TFT_HEIGHT 128 // GC9A01 240 x 240
 
 // For ST7735 ONLY, define the type of display, originally this was based on the
 // colour of the tab on the screen protector film but this is not always true, so try
@@ -99,22 +99,22 @@
 // Comment out ALL BUT ONE of these options for a ST7735 display driver, save this
 // this User_Setup file, then rebuild and upload the sketch to the board again:
 
-// #define ST7735_INITB
-// #define ST7735_GREENTAB
-// #define ST7735_GREENTAB2
-// #define ST7735_GREENTAB3
-// #define ST7735_GREENTAB128    // For 128 x 128 display
-// #define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
-// #define ST7735_ROBOTLCD       // For some RobotLCD Arduino shields (128x160, BGR, https://docs.arduino.cc/retired/getting-started-guides/TFT)
-// #define ST7735_REDTAB
-// #define ST7735_BLACKTAB
-// #define ST7735_REDTAB160x80   // For 160 x 80 display with 24 pixel offset
+//#define ST7735_INITB
+//#define ST7735_GREENTAB
+#define ST7735_GREENTAB2
+//#define ST7735_GREENTAB3
+//#define ST7735_GREENTAB128    // For 128 x 128 display
+//#define ST7735_GREENTAB160x80 // For 160 x 80 display (BGR, inverted, 26 offset)
+//#define ST7735_ROBOTLCD       // For some RobotLCD Arduino shields (128x160, BGR, https://docs.arduino.cc/retired/getting-started-guides/TFT)
+//#define ST7735_REDTAB
+//#define ST7735_BLACKTAB
+//#define ST7735_REDTAB160x80   // For 160 x 80 display with 24 pixel offset
 
 // If colours are inverted (white shows as black) then uncomment one of the next
 // 2 lines try both options, one of the options should correct the inversion.
 
-// #define TFT_INVERSION_ON
-// #define TFT_INVERSION_OFF
+//#define TFT_INVERSION_ON
+#define TFT_INVERSION_OFF
 
 
 // ##################################################################################
@@ -167,6 +167,7 @@
 // ###### EDIT THE PIN NUMBERS IN THE LINES FOLLOWING TO SUIT YOUR ESP8266 SETUP ######
 
 // For NodeMCU - use pin numbers in the form PIN_Dx where Dx is the NodeMCU pin designation
+/*
 #define TFT_MISO  PIN_D6  // Automatically assigned with ESP8266 if not defined
 #define TFT_MOSI  PIN_D7  // Automatically assigned with ESP8266 if not defined
 #define TFT_SCLK  PIN_D5  // Automatically assigned with ESP8266 if not defined
@@ -174,6 +175,7 @@
 #define TFT_CS    PIN_D8  // Chip select control pin D8
 #define TFT_DC    PIN_D3  // Data Command control pin
 #define TFT_RST   PIN_D4  // Reset pin (could connect to NodeMCU RST, see next line)
+*/
 //#define TFT_RST  -1     // Set TFT_RST to -1 if the display RESET is connected to NodeMCU RST or 3.3V
 
 
@@ -209,12 +211,25 @@
 // For ESP32 Dev board (only tested with ILI9341 display)
 // The hardware SPI can be mapped to any pins
 
-//#define TFT_MISO 19
-//#define TFT_MOSI 23
-//#define TFT_SCLK 18
-//#define TFT_CS   15  // Chip select control pin
-//#define TFT_DC    2  // Data Command control pin
-//#define TFT_RST   4  // Reset pin (could connect to RST pin)
+// PIN used for the Xiao nrf52840 Sense and a 1.8' 128x160 TFT display
+/*
+    TFT     XIAO
+    ------------
+    GND	    GND
+    VCC	    3.3V
+    SCL	    D8 (SCK)
+    SDA	    D10 (MOSI)
+    RST	    D6
+    DC	    D5
+    CS	    D7
+    BLK	    D9 or 3.3V (for constant backlight)
+*/
+#define TFT_MISO -1
+#define TFT_MOSI D10
+#define TFT_SCLK D8
+#define TFT_CS   D7  // Chip select control pin
+#define TFT_DC   D5 // Data Command control pin
+#define TFT_RST  D6  // Reset pin (could connect to RST pin)
 //#define TFT_RST  -1  // Set TFT_RST to -1 if display RESET is connected to ESP32 board RST
 
 // For ESP32 Dev board (only tested with GC9A01 display)
@@ -362,7 +377,7 @@
 // #define SPI_FREQUENCY  20000000
 #define SPI_FREQUENCY  27000000
 // #define SPI_FREQUENCY  40000000
-// #define SPI_FREQUENCY  55000000 // STM32 SPI1 only (SPI2 maximum is 27MHz)
+//#define SPI_FREQUENCY  55000000 // STM32 SPI1 only (SPI2 maximum is 27MHz)
 // #define SPI_FREQUENCY  80000000
 
 // Optional reduced SPI frequency for reading TFT


### PR DESCRIPTION
Added a configuration for the Seeed Studio XIAO nRF52840 with a 1.8'' 128x160 TFT screen using ST7735S driver. 
Here's the pinout used:

`TFT Pin	Xiao nRF52840 Pin
GND	GND
VCC	3.3V
SCL	D8 (SCK)
SDA	D10 (MOSI)
RST	D6
DC	D5
CS	D7
BLK	D9 or 3.3V (for constant backlight)`