### PR TITLE
Update TFT_eSPI_ESP32_S3.h

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -556,9 +556,9 @@ SPI3_HOST = 2
     #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;  \
                                *_spi_w = D;              \
                                *_spi_cmd = SPI_UPDATE;   \
-                        while (*_spi_cmd & SPI_UPDATE);  \
+                        while (*_spi_cmd & SPI_UPDATE){};  \
                                *_spi_cmd = SPI_USR;      \
-                        while (*_spi_cmd & SPI_USR);
+                        while (*_spi_cmd & SPI_USR){};
   #endif
   // Write 8 bits
   #define tft_Write_8(C) TFT_WRITE_BITS(C, 8)
@@ -575,7 +575,7 @@ SPI3_HOST = 2
     #define tft_Write_16N(C) *_spi_mosi_dlen = 16-1;    \
                            *_spi_w = ((C)<<8 | (C)>>8); \
                            *_spi_cmd = SPI_UPDATE;      \
-                    while (*_spi_cmd & SPI_UPDATE);     \
+                    while (*_spi_cmd & SPI_UPDATE){};     \
                            *_spi_cmd = SPI_USR;
   #endif
 


### PR DESCRIPTION
Added {} to 3 lines to prevent compiler errors

In the version 5.3.2 of ESP-IDF and Arduino framework 3 the compiler would error at these 3 lines.  Putting in {} solves that issue