### PR TITLE
fixing indentation and compilation error for esp32-s3

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.h
+++ b/Processors/TFT_eSPI_ESP32_S3.h
@@ -553,12 +553,12 @@ SPI3_HOST = 2
                                *_spi_cmd = SPI_USR;      \
                         while (*_spi_cmd & SPI_USR);
   #else
-    #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;  \
-                               *_spi_w = D;              \
-                               *_spi_cmd = SPI_UPDATE;   \
-                        while (*_spi_cmd & SPI_UPDATE);  \
-                               *_spi_cmd = SPI_USR;      \
-                        while (*_spi_cmd & SPI_USR);
+    #define TFT_WRITE_BITS(D, B)  *_spi_mosi_dlen = B-1;  \
+                                  *_spi_w = D;              \
+                                  *_spi_cmd = SPI_UPDATE;   \
+                                  while (*_spi_cmd & SPI_UPDATE);  \
+                                  *_spi_cmd = SPI_USR;      \
+                                  while (*_spi_cmd & SPI_USR);
   #endif
   // Write 8 bits
   #define tft_Write_8(C) TFT_WRITE_BITS(C, 8)
@@ -575,7 +575,7 @@ SPI3_HOST = 2
     #define tft_Write_16N(C) *_spi_mosi_dlen = 16-1;    \
                            *_spi_w = ((C)<<8 | (C)>>8); \
                            *_spi_cmd = SPI_UPDATE;      \
-                    while (*_spi_cmd & SPI_UPDATE);     \
+                           while (*_spi_cmd & SPI_UPDATE);     \
                            *_spi_cmd = SPI_USR;
   #endif
 


### PR DESCRIPTION
Compilation fails on target `ESP32-S3` due to indentation issue

Fixes issue: https://github.com/Bodmer/TFT_eSPI/issues/3697  