### PR TITLE
LILYGO_T_DISPLAY_S3 Macro

### DIFF
--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -24,7 +24,9 @@
 
 // Only ONE line below should be uncommented to define your setup.  Add extra lines and files as needed.
 
+#ifndef LILYGO_T_DISPLAY_S3
 #include <User_Setup.h>           // Default setup is root library folder
+#endif
 
 //#include <User_Setups/Setup1_ILI9341.h>  // Setup file for ESP8266 configured for my ILI9341
 //#include <User_Setups/Setup2_ST7735.h>   // Setup file for ESP8266 configured for my ST7735
@@ -130,7 +132,9 @@
 
 //#include <User_Setups/Setup205_ESP32_TouchDown_S3.h>     // Setup file for the ESP32 TouchDown S3 based on ILI9488 480 x 320 TFT 
 
-//#include <User_Setups/Setup206_LilyGo_T_Display_S3.h>     // For the LilyGo T-Display S3 based ESP32S3 with ST7789 170 x 320 TFT
+#ifdef LILYGO_T_DISPLAY_S3
+#include <User_Setups/Setup206_LilyGo_T_Display_S3.h>     // For the LilyGo T-Display S3 based ESP32S3 with ST7789 170 x 320 TFT
+#endif
 //#include <User_Setups/Setup207_LilyGo_T_HMI.h>            // For the LilyGo T-HMI S3 based ESP32S3 with ST7789 240 x 320 TFT
 //#include <User_Setups/Setup209_LilyGo_T_Dongle_S3.h>      // For the LilyGo T-Dongle S3 based ESP32 with ST7735 80 x 160 TFT
 //#include <User_Setups/Setup210_LilyGo_T_Embed_S3.h>         // For the LilyGo T-Embed S3 based ESP32S3 with ST7789 170 x 320 TFT


### PR DESCRIPTION
Dear Bodmer,

I have been enjoying your library while teaching students at a University and really appreciate that. 

One thing I would like to add to this if you will is as follows.

The lab kit consists of LilyGo_T_Display_S3 and the students have been asked to modify the header file User_Setup_Select.h every time they created a new project under VSCode/PlatformIO. It's doable and not a big deal, but there are cases the students and I are spending time to deal with this instead of the main ideas.

So I would like to use the macro to have the project configured and use the right set of header files.
Once this is merged, the students just simply pass the macro in the platformio.ini as below.

Could you consider to merge this to your library?
```
[env:lilygo-t-display-s3]
platform = espressif32
board = lilygo-t-display-s3
framework = arduino
build_flags = -DARDUINO_USB_CDC_ON_BOOT=1 -DLILYGO_T_DISPLAY_S3
lib_deps = 
	bodmer/TFT_eSPI@^2.5.43
```