### PR TITLE
Add USER_SETUP_LOADED check to ESP-IDF config path

### DIFF
--- a/TFT_eSPI.h
+++ b/TFT_eSPI.h
@@ -37,7 +37,7 @@
 ***************************************************************************************/
 // Include header file that defines the fonts loaded, the TFT drivers
 // available and the pins to be used, etc. etc.
-#ifdef CONFIG_TFT_eSPI_ESPIDF
+#if defined (CONFIG_TFT_eSPI_ESPIDF) && !defined (USER_SETUP_LOADED)
   #include "TFT_config.h"
 #endif
 


### PR DESCRIPTION
Previously, if CONFIG_TFT_eSPI_ESPIDF was set, TFT_eSPI.h would unconditionally include TFT_config.h — even if USER_SETUP_LOADED was already defined (e.g., from User_Setup.h). This caused build errors due to missing or conflicting macros.

TFT_config.h is intended for ESP-IDF environments, while User_Setup.h is typically used in Arduino environments. However, this distinction breaks down when using PlatformIO with ESP-IDF as the base framework and Arduino as a component.

This change adds a check for USER_SETUP_LOADED even in the ESP-IDF codepath, giving users the flexibility to load their preferred configuration file. It avoids including TFT_config.h if a valid setup has already been provided.

This is especially useful in hybrid environments where ESP-IDF is used for system-level access (e.g., Bluetooth, low-level power control), but Arduino is used for everything else. In these cases, using User_Setup.h with PlatformIO may be preferred rather than relying on menuconfig.

This change maintains full compatibility with pure ESP-IDF setups that rely on TFT_config.h and idf.py menuconfig, while making the library more flexible in real-world mixed-mode builds.