### PR TITLE
fix indentation for esp32-c3

### DIFF
--- a/Processors/TFT_eSPI_ESP32_C3.h
+++ b/Processors/TFT_eSPI_ESP32_C3.h
@@ -533,17 +533,17 @@ SPI3_HOST = 2
 //*/
 //* Replacement slimmer macros
   #if !defined(CONFIG_IDF_TARGET_ESP32C3)
-    #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;  \
-                               *_spi_w = D;              \
-                               *_spi_cmd = SPI_USR;      \
-                        while (*_spi_cmd & SPI_USR);
+    #define TFT_WRITE_BITS(D, B)  *_spi_mosi_dlen = B-1;  \
+                                  *_spi_w = D;              \
+                                  *_spi_cmd = SPI_USR;      \
+                                  while (*_spi_cmd & SPI_USR);
   #else
-    #define TFT_WRITE_BITS(D, B) *_spi_mosi_dlen = B-1;  \
-                               *_spi_w = D;              \
-                               *_spi_cmd = SPI_UPDATE;   \
-                        while (*_spi_cmd & SPI_UPDATE);  \
-                               *_spi_cmd = SPI_USR;      \
-                        while (*_spi_cmd & SPI_USR);
+    #define TFT_WRITE_BITS(D, B)  *_spi_mosi_dlen = B-1;  \
+                                  *_spi_w = D;              \
+                                  *_spi_cmd = SPI_UPDATE;   \
+                                  while (*_spi_cmd & SPI_UPDATE);  \
+                                  *_spi_cmd = SPI_USR;      \
+                                  while (*_spi_cmd & SPI_USR);
   #endif
   // Write 8 bits
   #define tft_Write_8(C) TFT_WRITE_BITS(C, 8)
@@ -553,15 +553,15 @@ SPI3_HOST = 2
 
   // Future option for transfer without wait
   #if !defined(CONFIG_IDF_TARGET_ESP32C3)
-    #define tft_Write_16N(C) *_spi_mosi_dlen = 16-1;    \
-                           *_spi_w = ((C)<<8 | (C)>>8); \
-                           *_spi_cmd = SPI_USR;
+    #define tft_Write_16N(C)  *_spi_mosi_dlen = 16-1;    \
+                              *_spi_w = ((C)<<8 | (C)>>8); \
+                              *_spi_cmd = SPI_USR;
   #else
-    #define tft_Write_16N(C) *_spi_mosi_dlen = 16-1;    \
-                           *_spi_w = ((C)<<8 | (C)>>8); \
-                           *_spi_cmd = SPI_UPDATE;      \
-                    while (*_spi_cmd & SPI_UPDATE);     \
-                           *_spi_cmd = SPI_USR;
+    #define tft_Write_16N(C)  *_spi_mosi_dlen = 16-1;    \
+                              *_spi_w = ((C)<<8 | (C)>>8); \
+                              *_spi_cmd = SPI_UPDATE;      \
+                              while (*_spi_cmd & SPI_UPDATE);     \
+                              *_spi_cmd = SPI_USR;
   #endif
 
   // Write 16 bits


### PR DESCRIPTION
Similarly to #3698, this fixes "misleading indentation" in the ESP32-C3 header