### PR TITLE
Add support for 2.25" ST7789 76x284 TFT.

### DIFF
--- a/TFT_Drivers/ST7789_Defines.h
+++ b/TFT_Drivers/ST7789_Defines.h
@@ -27,6 +27,13 @@
   #endif
 #endif
 
+// 2.25" 76x284 Small Screen Color IPS TFT Display
+#if (TFT_HEIGHT == 284) && (TFT_WIDTH == 76)
+  #ifndef CGRAM_OFFSET
+    #define CGRAM_OFFSET
+  #endif
+#endif
+
 // 1.47" 172x320 Round Rectangle Color IPS TFT Display
 #if (TFT_HEIGHT == 320) && (TFT_WIDTH == 172)
   #ifndef CGRAM_OFFSET

--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -25,6 +25,11 @@
         colstart = 35;
         rowstart = 0;
       }
+      else if(_init_width == 76)
+      {
+        colstart = 82;
+        rowstart = 18;
+      }
       else
       {
         colstart = 0;
@@ -58,6 +63,11 @@
       {
         colstart = 0;
         rowstart = 35;
+      }
+      else if(_init_width == 76)
+      {
+        colstart = 18;
+        rowstart = 82;
       }
       else
       {
@@ -93,7 +103,11 @@
         colstart = 35;
         rowstart = 0;
       }
-      else
+      else if(_init_width == 76)
+      {
+        colstart = 82;
+        rowstart = 18;
+      } else
       {
         colstart = 0;
         rowstart = 80;
@@ -126,7 +140,11 @@
         colstart = 0;
         rowstart = 35;
       }
-      else
+      else if(_init_width == 76)
+      {
+        colstart = 18;
+        rowstart = 82;
+      } else
       {
         colstart = 80;
         rowstart = 0;


### PR DESCRIPTION
Hi!

I added support for 2.25" ST7789 76x284 TFT.

It is this one:
https://aliexpress.com/item/1005008920033631.html

Without this change I only see noise and sometimes an update depending on the orientation. I figured out this display needed column and row offsets, which appear to be 82 and 18.

This seems relevant to know:

```ini
  -DST7789_DRIVER=1
  -DTFT_WIDTH=76
  -DTFT_HEIGHT=284
```

I tested with all 4 rotations.

![image](https://github.com/user-attachments/assets/89b4af36-37e7-4d22-b18a-5780a57ac950)

![image](https://github.com/user-attachments/assets/aed5c134-b97f-4c90-bcf9-e041522f19ee)

![image](https://github.com/user-attachments/assets/8ff4a7a0-c32a-4a3e-90cc-5970c30a3222)

![image](https://github.com/user-attachments/assets/096efa0d-47ba-4b9f-8acf-dc65f5bb2db3)
