### PR TITLE
Added support for ST7789T3 driver

### DIFF
--- a/TFT_Drivers/ST7789T3_Defines.h
+++ b/TFT_Drivers/ST7789T3_Defines.h
@@ -1,0 +1,51 @@
+#ifndef TFT_WIDTH
+  #define TFT_WIDTH  240
+#endif
+#ifndef TFT_HEIGHT
+  #define TFT_HEIGHT 320
+#endif
+
+// Delay between some initialisation commands
+#define TFT_INIT_DELAY 0x80 // Not used unless commandlist invoked
+
+
+// Generic commands used by TFT_eSPI.cpp
+#define TFT_NOP     0x00
+#define TFT_SWRST   0x01
+
+#define TFT_SLPIN   0x10
+#define TFT_SLPOUT  0x11
+#define TFT_NORON   0x13
+
+#define TFT_INVOFF  0x20
+#define TFT_INVON   0x21
+#define TFT_DISPOFF 0x28
+#define TFT_DISPON  0x29
+#define TFT_CASET   0x2A
+#define TFT_PASET   0x2B
+#define TFT_RAMWR   0x2C
+#define TFT_RAMRD   0x2E
+#define TFT_MADCTL  0x36
+#define TFT_COLMOD  0x3A
+
+// Flags for TFT_MADCTL
+#define TFT_MAD_MY  0x80
+#define TFT_MAD_MX  0x40
+#define TFT_MAD_MV  0x20
+#define TFT_MAD_ML  0x10
+#define TFT_MAD_RGB 0x00
+#define TFT_MAD_BGR 0x08
+#define TFT_MAD_MH  0x04
+#define TFT_MAD_SS  0x02
+#define TFT_MAD_GS  0x01
+
+#define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+
+#define ST7789T3_GCTRL		  0xB7      // Gate control
+#define ST7789T3_LCMCTRL	  0xC0      // LCM control
+#define ST7789T3_IDSET		  0xC1      // ID setting
+#define ST7789T3_VDVVRHEN	  0xC2      // VDV and VRH command enable
+#define ST7789T3_VCMOFSET	  0xC5      // VCOMS offset set
+#define ST7789T3_PVGAMCTRL	0xE0      // Positive voltage gamma control
+#define ST7789T3_NVGAMCTRL	0xE1      // Negative voltage gamma control
+#define ST7789T3_PWCTRL2    0xE8      // Power control 2

--- a/TFT_Drivers/ST7789T3_Init.h
+++ b/TFT_Drivers/ST7789T3_Init.h
@@ -1,0 +1,87 @@
+{
+    // Adapted from Waveshare RP2350-Touch-LCD-2 board example for the Pico C SDK
+    writecommand(TFT_SLPOUT);
+    delay(120);
+
+    writecommand(TFT_COLMOD);     
+    writedata(0x05);
+
+    writecommand(0xF0); // ?? not found in the datasheet
+    writedata(0xC3);   
+
+    writecommand(0xF0); // ?? not found in the datasheet
+    writedata(0x96);   
+
+    writecommand(0xB4); // ?? not found in the datasheet
+    writedata(0x01);   
+
+    writecommand(ST7789T3_GCTRL);     
+    writedata(0xC6);   
+
+    writecommand(ST7789T3_LCMCTRL);     
+    writedata(0x80);   
+    writedata(0x45);   
+
+    writecommand(ST7789T3_IDSET);     
+    writedata(0x13);
+
+    writecommand(ST7789T3_VDVVRHEN);     
+    writedata(0xA7);   
+
+    writecommand(ST7789T3_VCMOFSET);     
+    writedata(0x0A);   
+
+    writecommand(ST7789T3_PWCTRL2);     
+    writedata(0x40);
+    writedata(0x8A);
+    writedata(0x00);
+    writedata(0x00);
+    writedata(0x29);
+    writedata(0x19);
+    writedata(0xA5);
+    writedata(0x33);
+
+    writecommand(ST7789T3_PVGAMCTRL);
+    writedata(0xD0);
+    writedata(0x08);
+    writedata(0x0F);
+    writedata(0x06);
+    writedata(0x06);
+    writedata(0x33);
+    writedata(0x30);
+    writedata(0x33);
+    writedata(0x47);
+    writedata(0x17);
+    writedata(0x13);
+    writedata(0x13);
+    writedata(0x2B);
+    writedata(0x31);
+
+    writecommand(ST7789T3_NVGAMCTRL);
+    writedata(0xD0);
+    writedata(0x0A);
+    writedata(0x11);
+    writedata(0x0B);
+    writedata(0x09);
+    writedata(0x07);
+    writedata(0x2F);
+    writedata(0x33);
+    writedata(0x47);
+    writedata(0x38);
+    writedata(0x15);
+    writedata(0x16);
+    writedata(0x2C);
+    writedata(0x32);
+
+    writecommand(0xF0); // ?? not found in the datasheet
+    writedata(0x3C);   
+
+    writecommand(0xF0); // ?? not found in the datasheet
+    writedata(0x69);   
+
+    delay(120);                
+
+    writecommand(TFT_INVON);     
+	
+    writecommand(TFT_DISPON); 
+}

--- a/TFT_Drivers/ST7789T3_Rotation.h
+++ b/TFT_Drivers/ST7789T3_Rotation.h
@@ -1,0 +1,28 @@
+  // This is the command sequence that rotates the ST7789T3 driver coordinate frame
+
+  writecommand(TFT_MADCTL);
+  rotation = m % 4;
+  switch (rotation) {
+    case 0: // Portrait
+      writedata(TFT_MAD_MX | TFT_MAD_COLOR_ORDER);
+      _width  = _init_width;
+      _height = _init_height;
+      break;
+
+    case 1: // Landscape (Portrait + 90)
+      writedata(TFT_MAD_MV | TFT_MAD_COLOR_ORDER);
+      _width  = _init_height;
+      _height = _init_width;
+      break;
+
+    case 2: // Inverter portrait
+      writedata(TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+      _width  = _init_width;
+      _height = _init_height;
+       break;
+    case 3: // Inverted landscape
+      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+      _width  = _init_height;
+      _height = _init_width;
+      break;
+  }

--- a/TFT_eSPI.cpp
+++ b/TFT_eSPI.cpp
@@ -769,6 +769,9 @@ void TFT_eSPI::init(uint8_t tc)
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Init.h"
 
+#elif defined(ST7789T3_DRIVER)
+    #include "TFT_Drivers/ST7789T3_Init.h"
+
 #endif
 
 #ifdef TFT_INVERSION_ON
@@ -869,6 +872,9 @@ void TFT_eSPI::setRotation(uint8_t m)
 
 #elif defined (HX8357C_DRIVER)
     #include "TFT_Drivers/HX8357C_Rotation.h"
+
+#elif defined (ST7789T3_DRIVER)
+    #include "TFT_Drivers/ST7789T3_Rotation.h"
 
 #endif
 

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -143,6 +143,7 @@
 
 //#include <User_Setups/Setup301_BW16_ST7735.h>            // Setup file for Bw16-based boards with ST7735 160 x 80 TFT
 //#include <User_Setups/Setup302_Waveshare_ESP32S3_GC9A01.h>            // Setup file for Waveshare ESP32-S3-Touch-LCD-1.28 board with GC9A01 240*240 TFT
+//#include <User_Setups/Setup303_Waveshare_RP2350_ST7789T3.h>           // Setup file for Waveshare RP2350-Touch-LCD-2 board with ST7789T3 240*320 TFT
 
 //#include <User_Setups/SetupX_Template.h>     // Template file for a setup
 
@@ -271,6 +272,9 @@
 #elif defined (HX8357C_DRIVER)
      #include "TFT_Drivers/HX8357C_Defines.h"
      #define  TFT_DRIVER 0x835C
+#elif defined (ST7789T3_DRIVER)
+     #include "TFT_Drivers/ST7789T3_Defines.h"
+     #define TFT_DRIVER 0x7789
 
                               // <<<<<<<<<<<<<<<<<<<<<<<< ADD NEW DRIVER HERE
                               // XYZZY_init.h and XYZZY_rotation.h must also be added in TFT_eSPI.cpp

--- a/User_Setups/Setup303_Waveshare_RP2350_ST7789T3.h
+++ b/User_Setups/Setup303_Waveshare_RP2350_ST7789T3.h
@@ -1,0 +1,26 @@
+// See SetupX_Template.h for all options available
+#define USER_SETUP_ID 303
+
+#define ST7789T3_DRIVER
+
+#define TFT_MOSI 19
+#define TFT_SCLK 18
+#define TFT_CS   17  // Chip select control pin
+#define TFT_DC   16  // Data Command control pin
+#define TFT_RST  20  // Reset pin (could connect to RST pin)
+#define TFT_BL   15
+#define TFT_BACKLIGHT_ON HIGH
+
+#define LOAD_GLCD   // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
+#define LOAD_FONT2  // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
+#define LOAD_FONT4  // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
+#define LOAD_FONT6  // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
+#define LOAD_FONT7  // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
+#define LOAD_FONT8  // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+#define LOAD_GFXFF  // FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
+#define SMOOTH_FONT
+
+#define TFT_WIDTH 240
+#define TFT_HEIGHT 320
+
+#define SPI_FREQUENCY  40000000

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -56,6 +56,7 @@
 //#define ILI9488_DRIVER     // WARNING: Do not connect ILI9488 display SDO to MISO if other devices share the SPI bus (TFT SDO does NOT tristate when CS is high)
 //#define ST7789_DRIVER      // Full configuration option, define additional parameters below for this display
 //#define ST7789_2_DRIVER    // Minimal configuration option, define additional parameters below for this display
+//#define ST7789T3_DRIVER
 //#define R61581_DRIVER
 //#define RM68120_DRIVER     // Untested
 //#define RM68140_DRIVER


### PR DESCRIPTION
This commit adds support for the ST7789T3 driver used for the [Waveshare RP2350-Touch-LCD-2](https://www.waveshare.com/wiki/RP2350-Touch-LCD-2).

I've included a user setup for that board.

I hope this can be useful