### PR TITLE
Fix issue with ESP32 C3 SPI not working on newer Arduino IDE

### DIFF
--- a/Processors/TFT_eSPI_ESP32_C3.h
+++ b/Processors/TFT_eSPI_ESP32_C3.h
@@ -68,7 +68,11 @@ SPI3_HOST = 2
 */
 
 // ESP32 specific SPI port selection - only SPI2_HOST available on C3
+#if ESP_ARDUINO_VERSION_MAJOR < 3
 #define SPI_PORT SPI2_HOST
+#else
+#define SPI_PORT 2
+#endif
 
 #ifdef RPI_DISPLAY_TYPE
   #define CMD_BITS (16-1)


### PR DESCRIPTION
After struggling to get the ESP32 C3 Super Mini working with a ST7789 TFT SPI I found this thread that solved, it seems the lib needs an update to keep working with latest Arduino versions, solution provided by "Moriyama":

For details and context please check:
https://esp32.com/viewtopic.php?t=37617&start=20#p142493