### PR TITLE
Setup302 define HSPI for esp32 v3.0 and above

### DIFF
--- a/User_Setups/Setup302_Waveshare_ESP32S3_GC9A01.h
+++ b/User_Setups/Setup302_Waveshare_ESP32S3_GC9A01.h
@@ -24,6 +24,8 @@
 #define TFT_WIDTH 240
 #define TFT_HEIGHT 240
 
+#define USE_HSPI_PORT          // Force HSPI for esp32 >= v3.0
+
 #define SPI_FREQUENCY  40000000
 
 #define SPI_READ_FREQUENCY  20000000


### PR DESCRIPTION
The Setup302_Waveshare_ESP32S3_GC9A01 is not supported with ESP32 Board version 3.0 and above, so you need to define HSPI to make it work. ✅