### PR TITLE
Update ILI9488_Rotation.h

### DIFF
--- a/TFT_Drivers/ILI9488_Rotation.h
+++ b/TFT_Drivers/ILI9488_Rotation.h
@@ -1,7 +1,7 @@
   // This is the command sequence that rotates the ILI9488 driver coordinate frame
 
   writecommand(TFT_MADCTL);
-  rotation = m % 4;
+  rotation = m % 8;
   switch (rotation) {
    case 0: // Portrait
      writedata(TFT_MAD_MX | TFT_MAD_BGR);
@@ -20,6 +20,26 @@
      break;
    case 3: // Inverted landscape
      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+     break;
+   case 4: // Portrait mirrored
+     writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+     break;
+   case 5: // Landscape (Portrait + 90) mirrored
+     writedata(TFT_MAD_MV | TFT_MAD_MX | TFT_MAD_BGR);
+      _width  = TFT_HEIGHT;
+      _height = TFT_WIDTH;
+     break;
+   case 6: // Inverter portrait mirrored
+     writedata(TFT_MAD_BGR);
+      _width  = TFT_WIDTH;
+      _height = TFT_HEIGHT;
+     break;
+   case 7: // Inverted landscape mirrored
+     writedata(TFT_MAD_MY | TFT_MAD_MV | TFT_MAD_BGR);
       _width  = TFT_HEIGHT;
       _height = TFT_WIDTH;
      break;


### PR DESCRIPTION
Add support for mirrored rotation (4-7) in ILI9488 driver.