### PR TITLE
Add DMA support for STM32L4xx series (CSELR-based request routing)

### DIFF
--- a/Processors/TFT_eSPI_STM32.h
+++ b/Processors/TFT_eSPI_STM32.h
@@ -198,6 +198,18 @@
       #define INIT_TFT_DATA_BUS spiHal.Instance = SPI2; \
                                 dmaHal.Instance = DMA1_Channel5
     #endif
+
+  #elif defined (STM32L4xx)
+    // STM32L4xx series with CSELR-based DMA request routing
+    #define STM32_DMA
+    #if (TFT_SPI_PORT == 1)
+      #define INIT_TFT_DATA_BUS spiHal.Instance = SPI1; \
+                                dmaHal.Instance = DMA1_Channel3
+    #elif (TFT_SPI_PORT == 2)
+      #define INIT_TFT_DATA_BUS spiHal.Instance = SPI2; \
+                                dmaHal.Instance = DMA1_Channel5
+    #endif
+
   #else
     // For STM32 processor with no implemented DMA support (yet)
     #if (TFT_SPI_PORT == 1)


### PR DESCRIPTION
The STM32L4xx series uses a channel-based DMA with CSELR (Channel Selection Register) for request routing, distinct from F2/F4/F7 (stream+channel), F1 (hardwired channels), and L4+ (DMAMUX).

Header (TFT_eSPI_STM32.h):
- Add STM32L4xx detection block between F1xx and the fallback
- Define STM32_DMA to enable DMA code paths
- Map SPI1_TX to DMA1_Channel3, SPI2_TX to DMA1_Channel5

Source (TFT_eSPI_STM32.c):
- Add DMA IRQ handlers for STM32L4 (DMA1_Channel3/5)
- Add initDMA() with CSELR routing via DMA_REQUEST_1
- Set spiHal.State = HAL_SPI_STATE_READY before first use, since spiHal is a separate handle from Arduino's internal SPI and only has Instance set via INIT_TFT_DATA_BUS. Without this, HAL_SPI_Transmit_DMA silently returns HAL_BUSY on every call.

Tested on STM32L412KB with ST7735 80x160 display on SPI1 at 40MHz.