### PR TITLE
Fix ESP32 S3 DMA for later ESP-IDF versions

### DIFF
--- a/Processors/TFT_eSPI_ESP32_S3.c
+++ b/Processors/TFT_eSPI_ESP32_S3.c
@@ -825,7 +825,7 @@ extern "C" void dma_end_callback();
 
 void IRAM_ATTR dma_end_callback(spi_transaction_t *spi_tx)
 {
-  WRITE_PERI_REG(SPI_DMA_CONF_REG(spi_host), 0);
+  WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_DMA_CH_AUTO), 0);
 }
 
 /***************************************************************************************


### PR DESCRIPTION
Fix ESP32 S3 DMA capability.

The SPI_DMA_CONF_REG(DMA_CHANNEL) must be cleared at the end of the transaction so that the next SPI DMA transaction outputs on the SPI port.

DMA_CHANNEL = SPI_DMA_CH_AUTO

Tested with Arduino board package version 3.3.6