### PR TITLE
fix: gpio_input_get() fails to compile in Arduino-ESP32 parallel mode; replace with REG_READ(GPIO_IN_REG)

### DIFF
--- a/Processors/TFT_eSPI_ESP32.c
+++ b/Processors/TFT_eSPI_ESP32.c
@@ -110,9 +110,9 @@ uint8_t TFT_eSPI::readByte(void)
 #if defined (TFT_PARALLEL_8_BIT)
   RD_L;
   uint32_t reg;           // Read all GPIO pins 0-31
-  reg = gpio_input_get(); // Read three times to allow for bus access time
-  reg = gpio_input_get();
-  reg = gpio_input_get(); // Data should be stable now
+  reg = REG_READ(GPIO_IN_REG); // Read three times to allow for bus access time
+  reg = REG_READ(GPIO_IN_REG);
+  reg = REG_READ(GPIO_IN_REG); // Data should be stable now
   RD_H;
 
   // Check GPIO bits used and build value


### PR DESCRIPTION
## Problem
In Arduino-ESP32 environments, `gpio_input_get()` used in `readByte()` 
fails to compile when using 8-bit parallel mode (`TFT_PARALLEL_8_BIT`).
This is due to the Arduino-ESP32 core not cleanly exposing every IDF 
function. This means `gpio_input_get()` is not properly resolved in the Arduino 
build chain, causing a compile error.

## Fix
Replace all three calls to `gpio_input_get()` with `REG_READ(GPIO_IN_REG)`,
which reads the GPIO input register directly at the hardware level with 
no dependency on the IDF abstraction layer.

The logic is identical, three reads to allow for bus access time — only 
the mechanism changes.

## Environment Tested
- ESP32-D (DevKit)
- Arduino-ESP32 core
- Arduino IDE
- 8-bit parallel display (ILI9486, 3.5" TFT)

## Notes
The library does not compile at all without this fix in the above environment. `REG_READ(GPIO_IN_REG)` is the correct low-level equivalent and works reliably.  
This fixes issues like the ones [here](https://github.com/Bodmer/TFT_eSPI/discussions/3361)