### PR TITLE
Update SPI_PORT logic for ESP32C3 and legacy ESP32 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/Processors/TFT_eSPI_ESP32_C3.h
+++ b/Processors/TFT_eSPI_ESP32_C3.h
@@ -64,10 +64,14 @@ SPI2_HOST = 1,  ///< actually SPI1
 SPI3_HOST = 2,  ///< actually SPI2
 */
 
-#if ESP_ARDUINO_VERSION_MAJOR < 3
-#define SPI_PORT SPI2_HOST
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C5 || \
+    CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2 || \
+    CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+  #define SPI_PORT 2  // SPI3_HOST = actually SPI2 hw, only one available
+#elif ESP_ARDUINO_VERSION_MAJOR < 3
+  #define SPI_PORT SPI2_HOST  // legacy ESP32 classic
 #else
-#define SPI_PORT 2
+  #define SPI_PORT 2
 #endif
 
 #ifdef RPI_DISPLAY_TYPE


### PR DESCRIPTION
**Fix SPI_PORT selection for ESP32-C3 (and other non-classic targets) on Arduino 2.x**

The existing `#if ESP_ARDUINO_VERSION_MAJOR < 3` guard sets `SPI_PORT` to `SPI2_HOST` (value 1) on Arduino 2.x. However, per the ESP-IDF enumeration, `SPI2_HOST = 1` maps to the SPI1 hardware bus, which is reserved for internal flash on ESP32-C3 (and C5, C6, H2, S2, S3). The correct port for these targets is value `2` (`SPI3_HOST`, actually SPI2 hardware) — which is what the Arduino 3.x branch already hardcodes.

This replaces the Arduino version check with a chip target check using `CONFIG_IDF_TARGET_*` macros, so the correct port is selected regardless of Arduino version. The original classic ESP32 code path is unchanged.